### PR TITLE
One-line UVX Install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ wheels/
 
 node_modules/
 
-cleanup.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ wheels/
 .env
 
 node_modules/
+
+cleanup.sh

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,7 @@
+uv cache clean
+rm -rf ./build
+rm -rf mcp.json
+npx playwright uninstall
+uvx --from git+https://github.com/nandatheguntupalli/web-eval-agent.git webEvalAgent
+
+#   op-ONQvLZNIwG59yubZPeqpxS5jns8C9Xdd2qtZmIc1ReM

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,7 +1,0 @@
-uv cache clean
-rm -rf ./build
-rm -rf mcp.json
-npx playwright uninstall
-uvx --from git+https://github.com/nandatheguntupalli/web-eval-agent.git webEvalAgent
-
-#   op-ONQvLZNIwG59yubZPeqpxS5jns8C9Xdd2qtZmIc1ReM

--- a/clear.sh
+++ b/clear.sh
@@ -1,4 +1,1 @@
 uv clean && rm -rf ./build
-
-
-

--- a/clear.sh
+++ b/clear.sh
@@ -1,1 +1,4 @@
 uv clean && rm -rf ./build
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "playwright>=1.41.0",
     "flask>=3.1.0",
     "flask-socketio>=5.5.1",
+    "requests>=2.20.0",
 ]
 
 [project.scripts]

--- a/rerun.sh
+++ b/rerun.sh
@@ -3,9 +3,6 @@ rm -rf ./mcp.json
 rm -rf ./mcp.lock
 rm -rf ./mcp.lockb
 rm -rf ./mcp.lockb.tmp
-rm -rf ./mcp.lockb.tmp.tmp
-rm -rf ./mcp.lockb.tmp.tmp.tmp
-rm -rf ./mcp.lockb.tmp.tmp.tmp.tmp
 rm -rf ~/.operative/config.json
 
 npx playwright uninstall --all

--- a/rerun.sh
+++ b/rerun.sh
@@ -1,0 +1,15 @@
+uv clean && rm -rf ./build
+rm -rf ./mcp.json
+rm -rf ./mcp.lock
+rm -rf ./mcp.lockb
+rm -rf ./mcp.lockb.tmp
+rm -rf ./mcp.lockb.tmp.tmp
+rm -rf ./mcp.lockb.tmp.tmp.tmp
+rm -rf ./mcp.lockb.tmp.tmp.tmp.tmp
+
+npx playwright uninstall --all
+rm ~/.cursor/mcp.json
+
+# uvx --from git+https://github.com/nandatheguntupalli/web-eval-agent.git webEvalAgent
+
+#  OPERATIVE_API_KEY=<KEY> uv run webEvalAgent/mcp_server.py

--- a/rerun.sh
+++ b/rerun.sh
@@ -6,6 +6,7 @@ rm -rf ./mcp.lockb.tmp
 rm -rf ./mcp.lockb.tmp.tmp
 rm -rf ./mcp.lockb.tmp.tmp.tmp
 rm -rf ./mcp.lockb.tmp.tmp.tmp.tmp
+rm -rf ~/.operative/config.json
 
 npx playwright uninstall --all
 rm ~/.cursor/mcp.json

--- a/uv.lock
+++ b/uv.lock
@@ -1586,6 +1586,7 @@ dependencies = [
     { name = "mcp" },
     { name = "playwright" },
     { name = "python-dotenv" },
+    { name = "requests" },
 ]
 
 [package.metadata]
@@ -1601,6 +1602,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "playwright", specifier = ">=1.41.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "requests", specifier = ">=2.20.0" },
 ]
 
 [[package]]

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -404,39 +404,25 @@ def main():
                 pass
                 
         # First get and validate API key regardless of configuration state
-        send_log(f"\n{BLUE}{BOLD}=== API Key Configuration ==={NC}\n", "🔑")
-        send_log(f"{BOLD}Obtaining and validating API key...{NC}", "🔑")
         operative_key = get_and_validate_api_key()
         if not operative_key:
-            send_log(f"{RED}✗ Critical: Operative API key could not be obtained or validated. Exiting.{NC}", "❌")
             return # Exit if no key
             
-        send_log(f"{BOLD}Using Operative API Key ending with ...{operative_key[-4:] if len(operative_key) > 4 else operative_key}{NC}", "🔑")
         
         # If not already configured, set up the MCP configuration with the API key
         if not is_already_configured:
-            send_log(f"\n{BLUE}{BOLD}=== Setting up configuration ==={NC}\n", "⚙️")
             # Configure MCP with API key
             _configure_cursor_mcp_json(agent_project_path, operative_key)
 
             # Ensure Playwright browsers are installed
-            send_log(f"\n{BLUE}{BOLD}=== Checking dependencies ==={NC}\n", "🔍")
-            send_log(f"{BOLD}Checking for Playwright browser installation...{NC}", "🔍")
             ensure_playwright_browsers()
-            
-            # Installation complete; instruct user to restart and exit
-            send_log(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n", "✅")
-            send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
             return
         else:
             # We're running in server mode - don't update MCP config as it's already configured
-            send_log(f"{BOLD}Found existing configuration. Using current settings.{NC}", "📝")
-            
-            send_log(f"{BOLD}API key validated. Starting MCP server...{NC}", "🛰️")
             # Run the FastMCP server
             mcp.run(transport='stdio')
 
-    except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
+    except ValueError as e:
         send_log(f"{RED}✗ Agent startup failed due to API key issue: {e}{NC}", "❌")
     except Exception as e:
         send_log(f"{RED}✗ An unexpected error occurred during agent startup: {e}\n{traceback.format_exc()}{NC}", "❌")

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -60,32 +60,6 @@ YELLOW = '\033[1;33m'
 NC = '\033[0m' # No Color
 BOLD = '\033[1m'
 
-# ASCII Art for startup logo
-OPERATIVE_LOGO = """                                    $$$$                                    
-                                 $$$    $$$                                 
-                              $$$          $$$                              
-                           $$$     $$$$$$     $$$                           
-                        $$$     $$$  $$  $$$     $$$c                       
-                    c$$$     $$$     $$     $$$     $$$$                    
-                   $$$$      $$$x    $$     $$$      $$$$                   
-                   $$  $$$      >$$$ $$ ;$$$      $$$  $$                   
-                   $$     $$$       $$$$8      $$$     $$                   
-                   $$        $$$            $$$        $$                   
-                   $$   $$$     $$$$     $$$     $$$   $$                   
-                   $$   $  $$$     I$$$$$     $$$  $   $$                   
-                   $$   $     $$$    $$    $$$     $   $$                   
-                   $$   $     $$$$   $$   $$$$     $   $$                   
-                   $$   $  $$$   $   $$   $   $$$  $   $$                   
-                   $$   $$$      $   $$   $      $$$   $$                   
-                   $$     $$$    $   $$   $    $$$     $$                   
-                    $$$      $$$ $   $$   $ $$$      $$$                    
-                       $$$      $$   $$   $$      $$$                       
-                          $$$        $$        $$$                          
-                             $$$     $$     $$$                             
-                                $$$  $$  $$$                                
-                                   $$$$$$                                   
-"""
-
 def ensure_playwright_browsers():
     """Checks and installs Playwright browsers if necessary."""
     try:
@@ -396,10 +370,6 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         )]
 
 def main():
-    # Print the ASCII logo
-    send_log(OPERATIVE_LOGO, "🚀")
-    send_log(f"\n{BLUE}{BOLD}=== 🚀 Welcome to the Operative Web Eval Agent ===\n{NC}", "🚀")
-    
     try:
         send_log(f"{BOLD}Operative Web Eval Agent starting up...{NC}", "🚀")
         
@@ -413,7 +383,6 @@ def main():
         except NameError: # __file__ not defined (e.g. in interactive interpreter or frozen app)
             # Fallback to current working directory, might not always be correct if script is run from elsewhere
             agent_project_path = Path(".").resolve()
-            send_log(f"{YELLOW}ℹ Could not determine agent script path via __file__, falling back to CWD: {agent_project_path}{NC}", "⚠️")
 
         # Check if we need to configure MCP or if we're running in server mode
         cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -335,24 +335,23 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
     is_valid = await validate_api_key(api_key)
 
     if not is_valid:
-        error_message_str = f"❌ Error: API Key validation failed when running the tool.\\n"
-        error_message_str += f"   Reason: Invalid API key or usage limit reached.\\n"
-        error_message_str += "   👉 Please check your API key or subscribe at https://operative.sh if it's a limit issue."
+        error_message_str = "❌ Error: API Key validation failed when running the tool.\n"
+        error_message_str += "   Reason: Free tier limit reached.\n"
+        error_message_str += "   👉 Please subscribe at https://operative.sh to continue."
         return [TextContent(type="text", text=error_message_str)]
     try:
-        # Generate a new tool_call_id for this specific tool call
         tool_call_id = str(uuid.uuid4())
         return await handle_web_evaluation(
             {"url": url, "task": task, "headless": headless, "tool_call_id": tool_call_id},
             ctx,
-            api_key # Pass the validated key
+            api_key
         )
     except Exception as e:
         tb = traceback.format_exc()
-        send_log(f"{RED}✗ Error executing web_eval_agent: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌")
+        send_log(f"Error executing web_eval_agent: {str(e)}\nTraceback:\n{tb}", "❌")
         return [TextContent(
             type="text",
-            text=f"Error executing web_eval_agent: {str(e)}\\n\\nTraceback:\\n{tb}"
+            text=f"Error executing web_eval_agent: {str(e)}\n\nTraceback:\n{tb}"
         )]
 
 @mcp.tool(name=BrowserTools.SETUP_BROWSER_STATE)
@@ -377,11 +376,10 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
 
     if not is_valid:
         error_message_str = "❌ Error: API Key validation failed when running the tool.\n"
-        error_message_str += "   Reason: Invalid API key or usage limit reached.\n"
-        error_message_str += "   👉 Please subscribe at https://operative.sh if it's a limit issue."
+        error_message_str += "   Reason: Free tier limit reached.\n"
+        error_message_str += "   👉 Please subscribe at https://operative.sh to continue."
         return [TextContent(type="text", text=error_message_str)]
     try:
-        # Generate a new tool_call_id for this specific tool call
         tool_call_id = str(uuid.uuid4())
         send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}", "📝")
         return await handle_setup_browser_state(
@@ -391,7 +389,7 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         )
     except Exception as e:
         tb = traceback.format_exc()
-        send_log(f"{RED}✗ Error executing setup_browser_state: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌")
+        send_log(f"Error executing setup_browser_state: {str(e)}\nTraceback:\n{tb}", "❌")
         return [TextContent(
             type="text",
             text=f"Error executing setup_browser_state: {str(e)}\n\nTraceback:\n{tb}"

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -313,22 +313,6 @@ def get_and_validate_api_key():
                 send_log(f"{RED}✗ API key validation failed. Exiting.{NC}", "❌")
                 raise ValueError("Invalid API key and user chose not to retry.")
 
-# --- End of new/modified functions ---
-
-# Get API key from environment variable
-# This initial check is now handled by get_and_validate_api_key() in main()
-# api_key = os.environ.get('OPERATIVE_API_KEY') 
-
-# Validate the API key
-# This initial validation is now handled by get_and_validate_api_key() in main()
-# if api_key:
-#     is_valid = asyncio.run(validate_api_key_original(api_key)) # Use renamed original
-#     if not is_valid:
-#         print("Error: Invalid API key. Please provide a valid OperativeAI API key in the OPERATIVE_API_KEY environment variable.")
-# else:
-#     print("Error: No API key provided. Please set the OPERATIVE_API_KEY environment variable.")
-
-
 @mcp.tool(name=BrowserTools.WEB_EVAL_AGENT)
 async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bool = False) -> list[TextContent]:
     """Evaluate the user experience / interface of a web application.
@@ -377,39 +361,6 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
             type="text",
             text=f"Error executing web_eval_agent: {str(e)}\\n\\nTraceback:\\n{tb}"
         )]
-
-# if __name__ == "__main__": # Keep this for direct testing if needed, but ensure API key is handled.
-#     try:
-#         # Ensure setup for direct run
-#         ensure_playwright_browsers()
-#         OPERATIVE_API_KEY_HOLDER["key"] = get_and_validate_api_key() # Ensures key for direct run
-        
-#         send_log(f"Running test evaluation with key: {OPERATIVE_API_KEY_HOLDER['key']}", "🧪")
-
-#         async def run_test_eval():
-#             # Need a dummy Context object for direct testing
-#             class DummyContext:
-#                 async def send_chunk(self, content):
-#                     send_log(f"DummyContext chunk: {content}", "📦")
-#                 async def send_message(self, message_type, content):
-#                     send_log(f"DummyContext message ({message_type}): {content}", "📦")
-            
-#             await web_eval_agent(
-#                 url="http://localhost:5173", 
-#                 task="general eval", 
-#                 working_directory=".", 
-#                 ctx=DummyContext() # Pass a dummy context
-#             )
-        
-#         asyncio.run(run_test_eval())
-#     except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
-#         send_log(f"Setup for direct run failed: {e}", "❌")
-#     except Exception as e:
-#         send_log(f"Error during direct test run: {e}\n{traceback.format_exc()}", "❌")
-#     finally:
-#         # Ensure resources are cleaned up
-#         # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
-#         send_log("Direct test run finished.", "🏁")
 
 @mcp.tool(name=BrowserTools.SETUP_BROWSER_STATE)
 async def setup_browser_state(url: str = None, ctx: Context = None) -> list[TextContent]:

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -63,73 +63,107 @@ BOLD = '\033[1m'
 def ensure_playwright_browsers():
     """Checks and installs Playwright browsers if necessary."""
     try:
+        send_log(f"{BOLD}Checking and installing Playwright browsers if necessary...{NC}", "🚀")
         # Using playwright's Python API to check/install is more robust if available.
         # For now, calling the CLI command.
         # Ensure playwright is in the path for uvx environment.
         process = subprocess.run(["playwright", "install", "--with-deps"], capture_output=True, text=True, check=False, timeout=300)
         if process.returncode == 0:
+            send_log(f"{GREEN}✓ Playwright browsers are installed successfully{NC}", "✅")
             if process.stdout:
-                pass
+                send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
             if process.stderr:
-                pass
+                send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
+        else:
+            send_log(f"Playwright browser installation command finished with code {process.returncode}.", "⚠️")
+            send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
+            send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
             # Not raising an error here to allow the agent to attempt to start,
             # but logging a significant warning. Tool usage will likely fail.
-            pass
+            send_log(f"{RED}✗ Playwright browser installation may have failed. The agent might not function correctly.{NC}", "❌")
     except FileNotFoundError:
-        pass
+        send_log(f"{RED}✗ Playwright command not found. Ensure Playwright is installed in the environment.{NC}", "❌")
+        raise Exception("Playwright command not found. Cannot ensure browser installation.")
     except subprocess.TimeoutExpired:
-        pass
+        send_log(f"{RED}✗ Playwright browser installation timed out after 5 minutes.{NC}", "❌")
+        raise Exception("Playwright browser installation timed out.")
     except Exception as e:
-        pass # Re-raise critical errors
+        send_log(f"{RED}✗ Error during Playwright browser setup: {e}{NC}", "❌")
+        raise # Re-raise critical errors
 
 def _configure_cursor_mcp_json(agent_project_path: Path, api_key=None):
     """Attempts to automatically configure Cursor's mcp.json file."""
     cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
     server_name = "web-eval-agent-operative"
     
-    if cursor_mcp_file.exists():
-        with open(cursor_mcp_file, 'r') as f:
-            try:
-                mcp_config = json.load(f)
-                if not isinstance(mcp_config, dict):
-                    mcp_config = {"mcpServers": {}}
-                if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
-                    mcp_config["mcpServers"] = {}
-            except json.JSONDecodeError:
+    send_log(f"{BOLD}Attempting to configure Cursor MCP server at {cursor_mcp_file}...{NC}", "⚙️")
+
+    mcp_config = {"mcpServers": {}}
+    try:
+        if cursor_mcp_file.exists():
+            send_log(f"{YELLOW}ℹ Found existing Cursor MCP file: {cursor_mcp_file}{NC}", "🔍")
+            with open(cursor_mcp_file, 'r') as f:
                 try:
-                    backup_path = cursor_mcp_file.with_suffix(".json.bak")
-                    cursor_mcp_file.rename(backup_path)
-                except OSError as e_backup:
-                    pass
-                mcp_config = {"mcpServers": {}}
-    else:
-        # Ensure .cursor directory exists
-        cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
+                    mcp_config = json.load(f)
+                    if not isinstance(mcp_config, dict):
+                        send_log(f"{YELLOW}ℹ Cursor MCP file is not a valid JSON object. Reinitializing.{NC}", "⚠️")
+                        mcp_config = {"mcpServers": {}}
+                    if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
+                        send_log(f"{YELLOW}ℹ 'mcpServers' key missing or invalid in Cursor MCP file. Reinitializing.{NC}", "⚠️")
+                        mcp_config["mcpServers"] = {}
+                except json.JSONDecodeError:
+                    send_log(f"{YELLOW}ℹ Error decoding JSON from {cursor_mcp_file}. Backing up and creating new config.{NC}", "⚠️")
+                    try:
+                        backup_path = cursor_mcp_file.with_suffix(".json.bak")
+                        cursor_mcp_file.rename(backup_path)
+                        send_log(f"{BOLD}Backed up corrupted MCP file to {backup_path}{NC}", "🛡️")
+                    except OSError as e_backup:
+                        send_log(f"{RED}✗ Could not back up corrupted MCP file: {e_backup}{NC}", "❌")
+                    mcp_config = {"mcpServers": {}}
+        else:
+            send_log(f"{BOLD}Cursor MCP file not found. Creating new one at {cursor_mcp_file}{NC}", "📝")
+            # Ensure .cursor directory exists
+            cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
 
-    server_config = {
-        "command": "uvx",
-        "args": [
-            "--from",
-            "git+https://github.com/nandatheguntupalli/web-eval-agent.git",
-            "webEvalAgent"
-        ],
-        "env": {}
-    }
+        server_config = {
+            "command": "uvx",
+            "args": [
+                "--from",
+                "git+https://github.com/nandatheguntupalli/web-eval-agent.git",
+                "webEvalAgent"
+            ],
+            "env": {}
+        }
+        
+        # Add API key to environment variables if provided
+        if api_key:
+            server_config["env"]["OPERATIVE_API_KEY"] = api_key
+            send_log(f"{GREEN}✓ API key added to Cursor MCP configuration{NC}", "✅")
+
+        # Add or update the server entry
+        mcp_config["mcpServers"][server_name] = server_config
+        send_log(f"{BOLD}Updating server entry for '{server_name}' in Cursor MCP config.{NC}", "🛠️")
+
+        with open(cursor_mcp_file, 'w') as f:
+            json.dump(mcp_config, f, indent=2)
+        
+        send_log(f"{GREEN}✓ Successfully updated Cursor MCP configuration at {cursor_mcp_file}.{NC}", "✅")
+        send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
+        
+        return cursor_mcp_file, mcp_config
+
+    except OSError as e_os:
+        send_log(f"{RED}✗ OS Error updating Cursor MCP file {cursor_mcp_file}: {e_os}{NC}", "❌")
+        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
+    except Exception as e_general:
+        send_log(f"{RED}✗ Unexpected error during Cursor MCP auto-configuration: {e_general}{NC}", "❌")
+        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
     
-    # Add API key to environment variables if provided
-    if api_key:
-        server_config["env"]["OPERATIVE_API_KEY"] = api_key
-
-    # Add or update the server entry
-    mcp_config["mcpServers"][server_name] = server_config
-
-    with open(cursor_mcp_file, 'w') as f:
-        json.dump(mcp_config, f, indent=2)
-    
-    return cursor_mcp_file, mcp_config
+    return None, None
 
 def _validate_api_key_server_side(api_key_to_validate):
     """Validates API key with the backend server."""
+    send_log(f"{BOLD}Validating API key with Operative servers...{NC}", "➡️")
     try:
         response = requests.get(
             "https://operative-backend.onrender.com/api/validate-key",
@@ -139,15 +173,20 @@ def _validate_api_key_server_side(api_key_to_validate):
         response.raise_for_status()
         data = response.json()
         if data.get("valid"):
+            send_log(f"{GREEN}✓ API key validated successfully server-side.{NC}", "✅")
             return True, data.get("message", "Valid")
         else:
             error_message = data.get("message", "Unknown validation error.")
+            send_log(f"{RED}✗ API key validation failed: {error_message}{NC}", "❌")
             return False, error_message
     except requests.exceptions.Timeout:
+        send_log(f"{RED}✗ API key validation timed out.{NC}", "❌")
         return False, "Connection to validation server timed out."
     except requests.exceptions.RequestException as e:
+        send_log(f"{RED}✗ Could not connect to validation server: {e}{NC}", "❌")
         return False, f"Could not connect to validation server: {e}"
     except json.JSONDecodeError:
+        send_log(f"{RED}✗ Invalid JSON response from validation server.{NC}", "❌")
         return False, "Invalid JSON response from validation server."
 
 def get_and_validate_api_key():
@@ -157,6 +196,10 @@ def get_and_validate_api_key():
 
     # Check MCP config first if environment variable is not set
     if not api_key:
+        send_log(f"{YELLOW}ℹ API key not found in environment variables. Checking MCP config...{NC}", "🔍")
+        cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
+        server_name = "web-eval-agent-operative"
+        
         if cursor_mcp_file.exists():
             try:
                 with open(cursor_mcp_file, 'r') as f:
@@ -170,34 +213,43 @@ def get_and_validate_api_key():
                         api_key = mcp_config["mcpServers"][server_name]["env"]["OPERATIVE_API_KEY"]
                         source = "MCP config file"
             except (json.JSONDecodeError, OSError):
-                pass
+                send_log(f"{YELLOW}ℹ Error reading Cursor MCP config file. Cannot retrieve API key.{NC}", "⚠️")
     
     # Check legacy config file if MCP config doesn't have the key
     if not api_key:
+        send_log(f"{YELLOW}ℹ API key not found in MCP config. Checking legacy config...{NC}", "🔍")
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         if CONFIG_FILE.exists():
             try:
                 config_data = json.loads(CONFIG_FILE.read_text())
                 api_key = config_data.get("OPERATIVE_API_KEY")
                 source = "legacy config file"
             except json.JSONDecodeError:
+                send_log(f"{YELLOW}ℹ Error reading legacy API key config file ({CONFIG_FILE}). File might be corrupted.{NC}", "⚠️")
                 api_key = None # Ensure api_key is None if file is corrupt
         
     if api_key:
+        send_log(f"{YELLOW}ℹ API key found in {source}.{NC}", "📝")
         is_valid, msg = _validate_api_key_server_side(api_key)
         if is_valid:
             OPERATIVE_API_KEY_HOLDER["key"] = api_key
             return api_key
         else:
+            send_log(f"{YELLOW}ℹ Invalid API key from {source}: {msg}. Will prompt user.{NC}", "⚠️")
             api_key = None # Reset api_key to trigger prompt
 
     # Prompt user if no valid key found yet
     while True:
+        send_log(f"{BOLD}An Operative.sh API key is required for this installation.{NC}", "🔑")
+        send_log(f"If you don't have one, please visit {BOLD}https://operative.sh{NC} to get your key.", "🔑")
         try:
             prompted_key = input("Please enter your Operative.sh API key: ")
         except EOFError: # Happens if stdin is not available (e.g. background process)
-            raise ValueError("API Key could not be obtained via input. Configure it via environment or MCP config.")
+             send_log(f"{RED}✗ Could not read API key from input (EOFError). Ensure OPERATIVE_API_KEY is set in the environment or MCP config.{NC}", "❌")
+             raise ValueError("API Key could not be obtained via input. Configure it via environment or MCP config.")
 
         if not prompted_key:
+            send_log(f"{RED}✗ API key cannot be empty. Please try again.{NC}", "❌")
             continue
         
         is_valid, msg = _validate_api_key_server_side(prompted_key)
@@ -209,20 +261,23 @@ def get_and_validate_api_key():
                 # Update MCP config with API key
                 mcp_file, mcp_config = _configure_cursor_mcp_json(Path(".").resolve(), prompted_key)
                 if mcp_file:
-                    OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
-                    return prompted_key
+                    send_log(f"{GREEN}✓ API key validated and saved to MCP config at {mcp_file}{NC}", "✅")
                 else:
                     # Fallback to legacy config if MCP config update fails
                     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
                     CONFIG_FILE.write_text(json.dumps({"OPERATIVE_API_KEY": prompted_key}))
+                    send_log(f"{YELLOW}ℹ Could not save API key to MCP config. Saved to legacy config at {CONFIG_FILE} instead.{NC}", "⚠️")
             except Exception as e:
-                pass
+                send_log(f"{YELLOW}ℹ Could not save API key to MCP config: {e}. Key will not be persisted.{NC}", "⚠️")
             
             OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
             return prompted_key
         else:
+            send_log(f"{RED}✗ Validation failed for entered API key: {msg}{NC}", "❌")
+            # Provide a way to exit if user doesn't want to retry
             retry = input("Invalid API key. Would you like to try again? (y/n): ")
             if retry.lower() != 'y':
+                send_log(f"{RED}✗ API key validation failed. Exiting.{NC}", "❌")
                 raise ValueError("Invalid API key and user chose not to retry.")
 
 @mcp.tool(name=BrowserTools.WEB_EVAL_AGENT)
@@ -300,6 +355,7 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         return [TextContent(type="text", text=error_message_str)]
     try:
         tool_call_id = str(uuid.uuid4())
+        send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}", "📝")
         return await handle_setup_browser_state(
             {"url": url, "tool_call_id": tool_call_id},
             ctx,

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -63,65 +63,51 @@ BOLD = '\033[1m'
 def ensure_playwright_browsers():
     """Checks and installs Playwright browsers if necessary."""
     try:
-        send_log(f"{BOLD}Checking and installing Playwright browsers if necessary...{NC}", "🚀")
         # Using playwright's Python API to check/install is more robust if available.
         # For now, calling the CLI command.
         # Ensure playwright is in the path for uvx environment.
         process = subprocess.run(["playwright", "install", "--with-deps"], capture_output=True, text=True, check=False, timeout=300)
         if process.returncode == 0:
-            send_log(f"{GREEN}✓ Playwright browsers are installed successfully{NC}", "✅")
             if process.stdout:
-                send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
+                pass
             if process.stderr:
-                send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
+                pass
+        
         else:
-            send_log(f"Playwright browser installation command finished with code {process.returncode}.", "⚠️")
-            send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
-            send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
             # Not raising an error here to allow the agent to attempt to start,
             # but logging a significant warning. Tool usage will likely fail.
-            send_log(f"{RED}✗ Playwright browser installation may have failed. The agent might not function correctly.{NC}", "❌")
+            pass
     except FileNotFoundError:
-        send_log(f"{RED}✗ Playwright command not found. Ensure Playwright is installed in the environment.{NC}", "❌")
-        raise Exception("Playwright command not found. Cannot ensure browser installation.")
+        pass
     except subprocess.TimeoutExpired:
-        send_log(f"{RED}✗ Playwright browser installation timed out after 5 minutes.{NC}", "❌")
-        raise Exception("Playwright browser installation timed out.")
+        pass
     except Exception as e:
-        send_log(f"{RED}✗ Error during Playwright browser setup: {e}{NC}", "❌")
-        raise # Re-raise critical errors
+        pass
 
 def _configure_cursor_mcp_json(agent_project_path: Path, api_key=None):
     """Attempts to automatically configure Cursor's mcp.json file."""
     cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
     server_name = "web-eval-agent-operative"
     
-    send_log(f"{BOLD}Attempting to configure Cursor MCP server at {cursor_mcp_file}...{NC}", "⚙️")
 
     mcp_config = {"mcpServers": {}}
     try:
         if cursor_mcp_file.exists():
-            send_log(f"{YELLOW}ℹ Found existing Cursor MCP file: {cursor_mcp_file}{NC}", "🔍")
             with open(cursor_mcp_file, 'r') as f:
                 try:
                     mcp_config = json.load(f)
                     if not isinstance(mcp_config, dict):
-                        send_log(f"{YELLOW}ℹ Cursor MCP file is not a valid JSON object. Reinitializing.{NC}", "⚠️")
                         mcp_config = {"mcpServers": {}}
                     if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
-                        send_log(f"{YELLOW}ℹ 'mcpServers' key missing or invalid in Cursor MCP file. Reinitializing.{NC}", "⚠️")
                         mcp_config["mcpServers"] = {}
                 except json.JSONDecodeError:
-                    send_log(f"{YELLOW}ℹ Error decoding JSON from {cursor_mcp_file}. Backing up and creating new config.{NC}", "⚠️")
                     try:
                         backup_path = cursor_mcp_file.with_suffix(".json.bak")
                         cursor_mcp_file.rename(backup_path)
-                        send_log(f"{BOLD}Backed up corrupted MCP file to {backup_path}{NC}", "🛡️")
                     except OSError as e_backup:
-                        send_log(f"{RED}✗ Could not back up corrupted MCP file: {e_backup}{NC}", "❌")
+                        pass
                     mcp_config = {"mcpServers": {}}
         else:
-            send_log(f"{BOLD}Cursor MCP file not found. Creating new one at {cursor_mcp_file}{NC}", "📝")
             # Ensure .cursor directory exists
             cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -138,32 +124,22 @@ def _configure_cursor_mcp_json(agent_project_path: Path, api_key=None):
         # Add API key to environment variables if provided
         if api_key:
             server_config["env"]["OPERATIVE_API_KEY"] = api_key
-            send_log(f"{GREEN}✓ API key added to Cursor MCP configuration{NC}", "✅")
 
         # Add or update the server entry
         mcp_config["mcpServers"][server_name] = server_config
-        send_log(f"{BOLD}Updating server entry for '{server_name}' in Cursor MCP config.{NC}", "🛠️")
 
         with open(cursor_mcp_file, 'w') as f:
             json.dump(mcp_config, f, indent=2)
         
-        send_log(f"{GREEN}✓ Successfully updated Cursor MCP configuration at {cursor_mcp_file}.{NC}", "✅")
-        send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
-        
         return cursor_mcp_file, mcp_config
 
     except OSError as e_os:
-        send_log(f"{RED}✗ OS Error updating Cursor MCP file {cursor_mcp_file}: {e_os}{NC}", "❌")
-        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
-    except Exception as e_general:
-        send_log(f"{RED}✗ Unexpected error during Cursor MCP auto-configuration: {e_general}{NC}", "❌")
-        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
+        pass
     
     return None, None
 
 def _validate_api_key_server_side(api_key_to_validate):
     """Validates API key with the backend server."""
-    send_log(f"{BOLD}Validating API key with Operative servers...{NC}", "➡️")
     try:
         response = requests.get(
             "https://operative-backend.onrender.com/api/validate-key",
@@ -173,20 +149,15 @@ def _validate_api_key_server_side(api_key_to_validate):
         response.raise_for_status()
         data = response.json()
         if data.get("valid"):
-            send_log(f"{GREEN}✓ API key validated successfully server-side.{NC}", "✅")
             return True, data.get("message", "Valid")
         else:
             error_message = data.get("message", "Unknown validation error.")
-            send_log(f"{RED}✗ API key validation failed: {error_message}{NC}", "❌")
             return False, error_message
     except requests.exceptions.Timeout:
-        send_log(f"{RED}✗ API key validation timed out.{NC}", "❌")
         return False, "Connection to validation server timed out."
     except requests.exceptions.RequestException as e:
-        send_log(f"{RED}✗ Could not connect to validation server: {e}{NC}", "❌")
         return False, f"Could not connect to validation server: {e}"
     except json.JSONDecodeError:
-        send_log(f"{RED}✗ Invalid JSON response from validation server.{NC}", "❌")
         return False, "Invalid JSON response from validation server."
 
 def get_and_validate_api_key():
@@ -196,7 +167,6 @@ def get_and_validate_api_key():
 
     # Check MCP config first if environment variable is not set
     if not api_key:
-        send_log(f"{YELLOW}ℹ API key not found in environment variables. Checking MCP config...{NC}", "🔍")
         cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
         server_name = "web-eval-agent-operative"
         
@@ -213,11 +183,10 @@ def get_and_validate_api_key():
                         api_key = mcp_config["mcpServers"][server_name]["env"]["OPERATIVE_API_KEY"]
                         source = "MCP config file"
             except (json.JSONDecodeError, OSError):
-                send_log(f"{YELLOW}ℹ Error reading Cursor MCP config file. Cannot retrieve API key.{NC}", "⚠️")
+                pass
     
     # Check legacy config file if MCP config doesn't have the key
     if not api_key:
-        send_log(f"{YELLOW}ℹ API key not found in MCP config. Checking legacy config...{NC}", "🔍")
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         if CONFIG_FILE.exists():
             try:
@@ -225,31 +194,24 @@ def get_and_validate_api_key():
                 api_key = config_data.get("OPERATIVE_API_KEY")
                 source = "legacy config file"
             except json.JSONDecodeError:
-                send_log(f"{YELLOW}ℹ Error reading legacy API key config file ({CONFIG_FILE}). File might be corrupted.{NC}", "⚠️")
-                api_key = None # Ensure api_key is None if file is corrupt
+                pass
         
     if api_key:
-        send_log(f"{YELLOW}ℹ API key found in {source}.{NC}", "📝")
         is_valid, msg = _validate_api_key_server_side(api_key)
         if is_valid:
             OPERATIVE_API_KEY_HOLDER["key"] = api_key
             return api_key
         else:
-            send_log(f"{YELLOW}ℹ Invalid API key from {source}: {msg}. Will prompt user.{NC}", "⚠️")
             api_key = None # Reset api_key to trigger prompt
 
     # Prompt user if no valid key found yet
     while True:
-        send_log(f"{BOLD}An Operative.sh API key is required for this installation.{NC}", "🔑")
-        send_log(f"If you don't have one, please visit {BOLD}https://operative.sh{NC} to get your key.", "🔑")
         try:
             prompted_key = input("Please enter your Operative.sh API key: ")
         except EOFError: # Happens if stdin is not available (e.g. background process)
-             send_log(f"{RED}✗ Could not read API key from input (EOFError). Ensure OPERATIVE_API_KEY is set in the environment or MCP config.{NC}", "❌")
              raise ValueError("API Key could not be obtained via input. Configure it via environment or MCP config.")
 
         if not prompted_key:
-            send_log(f"{RED}✗ API key cannot be empty. Please try again.{NC}", "❌")
             continue
         
         is_valid, msg = _validate_api_key_server_side(prompted_key)
@@ -261,23 +223,23 @@ def get_and_validate_api_key():
                 # Update MCP config with API key
                 mcp_file, mcp_config = _configure_cursor_mcp_json(Path(".").resolve(), prompted_key)
                 if mcp_file:
-                    send_log(f"{GREEN}✓ API key validated and saved to MCP config at {mcp_file}{NC}", "✅")
+                    pass
                 else:
                     # Fallback to legacy config if MCP config update fails
                     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
                     CONFIG_FILE.write_text(json.dumps({"OPERATIVE_API_KEY": prompted_key}))
-                    send_log(f"{YELLOW}ℹ Could not save API key to MCP config. Saved to legacy config at {CONFIG_FILE} instead.{NC}", "⚠️")
+                    pass
             except Exception as e:
-                send_log(f"{YELLOW}ℹ Could not save API key to MCP config: {e}. Key will not be persisted.{NC}", "⚠️")
+                pass
             
             OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
             return prompted_key
         else:
-            send_log(f"{RED}✗ Validation failed for entered API key: {msg}{NC}", "❌")
+    
             # Provide a way to exit if user doesn't want to retry
             retry = input("Invalid API key. Would you like to try again? (y/n): ")
             if retry.lower() != 'y':
-                send_log(f"{RED}✗ API key validation failed. Exiting.{NC}", "❌")
+
                 raise ValueError("Invalid API key and user chose not to retry.")
 
 @mcp.tool(name=BrowserTools.WEB_EVAL_AGENT)
@@ -315,6 +277,7 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
         return [TextContent(type="text", text=error_message_str)]
     try:
         tool_call_id = str(uuid.uuid4())
+        send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}")
         return await handle_web_evaluation(
             {"url": url, "task": task, "headless": headless, "tool_call_id": tool_call_id},
             ctx,
@@ -355,7 +318,6 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         return [TextContent(type="text", text=error_message_str)]
     try:
         tool_call_id = str(uuid.uuid4())
-        send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}", "📝")
         return await handle_setup_browser_state(
             {"url": url, "tool_call_id": tool_call_id},
             ctx,

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -63,107 +63,73 @@ BOLD = '\033[1m'
 def ensure_playwright_browsers():
     """Checks and installs Playwright browsers if necessary."""
     try:
-        send_log(f"{BOLD}Checking and installing Playwright browsers if necessary...{NC}", "🚀")
         # Using playwright's Python API to check/install is more robust if available.
         # For now, calling the CLI command.
         # Ensure playwright is in the path for uvx environment.
         process = subprocess.run(["playwright", "install", "--with-deps"], capture_output=True, text=True, check=False, timeout=300)
         if process.returncode == 0:
-            send_log(f"{GREEN}✓ Playwright browsers are installed successfully{NC}", "✅")
             if process.stdout:
-                send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
+                pass
             if process.stderr:
-                send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
-        else:
-            send_log(f"Playwright browser installation command finished with code {process.returncode}.", "⚠️")
-            send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
-            send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
+                pass
             # Not raising an error here to allow the agent to attempt to start,
             # but logging a significant warning. Tool usage will likely fail.
-            send_log(f"{RED}✗ Playwright browser installation may have failed. The agent might not function correctly.{NC}", "❌")
+            pass
     except FileNotFoundError:
-        send_log(f"{RED}✗ Playwright command not found. Ensure Playwright is installed in the environment.{NC}", "❌")
-        raise Exception("Playwright command not found. Cannot ensure browser installation.")
+        pass
     except subprocess.TimeoutExpired:
-        send_log(f"{RED}✗ Playwright browser installation timed out after 5 minutes.{NC}", "❌")
-        raise Exception("Playwright browser installation timed out.")
+        pass
     except Exception as e:
-        send_log(f"{RED}✗ Error during Playwright browser setup: {e}{NC}", "❌")
-        raise # Re-raise critical errors
+        pass # Re-raise critical errors
 
 def _configure_cursor_mcp_json(agent_project_path: Path, api_key=None):
     """Attempts to automatically configure Cursor's mcp.json file."""
     cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
     server_name = "web-eval-agent-operative"
     
-    send_log(f"{BOLD}Attempting to configure Cursor MCP server at {cursor_mcp_file}...{NC}", "⚙️")
-
-    mcp_config = {"mcpServers": {}}
-    try:
-        if cursor_mcp_file.exists():
-            send_log(f"{YELLOW}ℹ Found existing Cursor MCP file: {cursor_mcp_file}{NC}", "🔍")
-            with open(cursor_mcp_file, 'r') as f:
-                try:
-                    mcp_config = json.load(f)
-                    if not isinstance(mcp_config, dict):
-                        send_log(f"{YELLOW}ℹ Cursor MCP file is not a valid JSON object. Reinitializing.{NC}", "⚠️")
-                        mcp_config = {"mcpServers": {}}
-                    if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
-                        send_log(f"{YELLOW}ℹ 'mcpServers' key missing or invalid in Cursor MCP file. Reinitializing.{NC}", "⚠️")
-                        mcp_config["mcpServers"] = {}
-                except json.JSONDecodeError:
-                    send_log(f"{YELLOW}ℹ Error decoding JSON from {cursor_mcp_file}. Backing up and creating new config.{NC}", "⚠️")
-                    try:
-                        backup_path = cursor_mcp_file.with_suffix(".json.bak")
-                        cursor_mcp_file.rename(backup_path)
-                        send_log(f"{BOLD}Backed up corrupted MCP file to {backup_path}{NC}", "🛡️")
-                    except OSError as e_backup:
-                        send_log(f"{RED}✗ Could not back up corrupted MCP file: {e_backup}{NC}", "❌")
+    if cursor_mcp_file.exists():
+        with open(cursor_mcp_file, 'r') as f:
+            try:
+                mcp_config = json.load(f)
+                if not isinstance(mcp_config, dict):
                     mcp_config = {"mcpServers": {}}
-        else:
-            send_log(f"{BOLD}Cursor MCP file not found. Creating new one at {cursor_mcp_file}{NC}", "📝")
-            # Ensure .cursor directory exists
-            cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
+                if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
+                    mcp_config["mcpServers"] = {}
+            except json.JSONDecodeError:
+                try:
+                    backup_path = cursor_mcp_file.with_suffix(".json.bak")
+                    cursor_mcp_file.rename(backup_path)
+                except OSError as e_backup:
+                    pass
+                mcp_config = {"mcpServers": {}}
+    else:
+        # Ensure .cursor directory exists
+        cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
 
-        server_config = {
-            "command": "uvx",
-            "args": [
-                "--from",
-                "git+https://github.com/nandatheguntupalli/web-eval-agent.git",
-                "webEvalAgent"
-            ],
-            "env": {}
-        }
-        
-        # Add API key to environment variables if provided
-        if api_key:
-            server_config["env"]["OPERATIVE_API_KEY"] = api_key
-            send_log(f"{GREEN}✓ API key added to Cursor MCP configuration{NC}", "✅")
-
-        # Add or update the server entry
-        mcp_config["mcpServers"][server_name] = server_config
-        send_log(f"{BOLD}Updating server entry for '{server_name}' in Cursor MCP config.{NC}", "🛠️")
-
-        with open(cursor_mcp_file, 'w') as f:
-            json.dump(mcp_config, f, indent=2)
-        
-        send_log(f"{GREEN}✓ Successfully updated Cursor MCP configuration at {cursor_mcp_file}.{NC}", "✅")
-        send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
-        
-        return cursor_mcp_file, mcp_config
-
-    except OSError as e_os:
-        send_log(f"{RED}✗ OS Error updating Cursor MCP file {cursor_mcp_file}: {e_os}{NC}", "❌")
-        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
-    except Exception as e_general:
-        send_log(f"{RED}✗ Unexpected error during Cursor MCP auto-configuration: {e_general}{NC}", "❌")
-        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
+    server_config = {
+        "command": "uvx",
+        "args": [
+            "--from",
+            "git+https://github.com/nandatheguntupalli/web-eval-agent.git",
+            "webEvalAgent"
+        ],
+        "env": {}
+    }
     
-    return None, None
+    # Add API key to environment variables if provided
+    if api_key:
+        server_config["env"]["OPERATIVE_API_KEY"] = api_key
+
+    # Add or update the server entry
+    mcp_config["mcpServers"][server_name] = server_config
+
+    with open(cursor_mcp_file, 'w') as f:
+        json.dump(mcp_config, f, indent=2)
+    
+    return cursor_mcp_file, mcp_config
 
 def _validate_api_key_server_side(api_key_to_validate):
     """Validates API key with the backend server."""
-    send_log(f"{BOLD}Validating API key with Operative servers...{NC}", "➡️")
     try:
         response = requests.get(
             "https://operative-backend.onrender.com/api/validate-key",
@@ -173,20 +139,15 @@ def _validate_api_key_server_side(api_key_to_validate):
         response.raise_for_status()
         data = response.json()
         if data.get("valid"):
-            send_log(f"{GREEN}✓ API key validated successfully server-side.{NC}", "✅")
             return True, data.get("message", "Valid")
         else:
             error_message = data.get("message", "Unknown validation error.")
-            send_log(f"{RED}✗ API key validation failed: {error_message}{NC}", "❌")
             return False, error_message
     except requests.exceptions.Timeout:
-        send_log(f"{RED}✗ API key validation timed out.{NC}", "❌")
         return False, "Connection to validation server timed out."
     except requests.exceptions.RequestException as e:
-        send_log(f"{RED}✗ Could not connect to validation server: {e}{NC}", "❌")
         return False, f"Could not connect to validation server: {e}"
     except json.JSONDecodeError:
-        send_log(f"{RED}✗ Invalid JSON response from validation server.{NC}", "❌")
         return False, "Invalid JSON response from validation server."
 
 def get_and_validate_api_key():
@@ -196,10 +157,6 @@ def get_and_validate_api_key():
 
     # Check MCP config first if environment variable is not set
     if not api_key:
-        send_log(f"{YELLOW}ℹ API key not found in environment variables. Checking MCP config...{NC}", "🔍")
-        cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
-        server_name = "web-eval-agent-operative"
-        
         if cursor_mcp_file.exists():
             try:
                 with open(cursor_mcp_file, 'r') as f:
@@ -213,43 +170,34 @@ def get_and_validate_api_key():
                         api_key = mcp_config["mcpServers"][server_name]["env"]["OPERATIVE_API_KEY"]
                         source = "MCP config file"
             except (json.JSONDecodeError, OSError):
-                send_log(f"{YELLOW}ℹ Error reading Cursor MCP config file. Cannot retrieve API key.{NC}", "⚠️")
+                pass
     
     # Check legacy config file if MCP config doesn't have the key
     if not api_key:
-        send_log(f"{YELLOW}ℹ API key not found in MCP config. Checking legacy config...{NC}", "🔍")
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         if CONFIG_FILE.exists():
             try:
                 config_data = json.loads(CONFIG_FILE.read_text())
                 api_key = config_data.get("OPERATIVE_API_KEY")
                 source = "legacy config file"
             except json.JSONDecodeError:
-                send_log(f"{YELLOW}ℹ Error reading legacy API key config file ({CONFIG_FILE}). File might be corrupted.{NC}", "⚠️")
                 api_key = None # Ensure api_key is None if file is corrupt
         
     if api_key:
-        send_log(f"{YELLOW}ℹ API key found in {source}.{NC}", "📝")
         is_valid, msg = _validate_api_key_server_side(api_key)
         if is_valid:
             OPERATIVE_API_KEY_HOLDER["key"] = api_key
             return api_key
         else:
-            send_log(f"{YELLOW}ℹ Invalid API key from {source}: {msg}. Will prompt user.{NC}", "⚠️")
             api_key = None # Reset api_key to trigger prompt
 
     # Prompt user if no valid key found yet
     while True:
-        send_log(f"{BOLD}An Operative.sh API key is required for this installation.{NC}", "🔑")
-        send_log(f"If you don't have one, please visit {BOLD}https://operative.sh{NC} to get your key.", "🔑")
         try:
             prompted_key = input("Please enter your Operative.sh API key: ")
         except EOFError: # Happens if stdin is not available (e.g. background process)
-             send_log(f"{RED}✗ Could not read API key from input (EOFError). Ensure OPERATIVE_API_KEY is set in the environment or MCP config.{NC}", "❌")
-             raise ValueError("API Key could not be obtained via input. Configure it via environment or MCP config.")
+            raise ValueError("API Key could not be obtained via input. Configure it via environment or MCP config.")
 
         if not prompted_key:
-            send_log(f"{RED}✗ API key cannot be empty. Please try again.{NC}", "❌")
             continue
         
         is_valid, msg = _validate_api_key_server_side(prompted_key)
@@ -261,23 +209,20 @@ def get_and_validate_api_key():
                 # Update MCP config with API key
                 mcp_file, mcp_config = _configure_cursor_mcp_json(Path(".").resolve(), prompted_key)
                 if mcp_file:
-                    send_log(f"{GREEN}✓ API key validated and saved to MCP config at {mcp_file}{NC}", "✅")
+                    OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
+                    return prompted_key
                 else:
                     # Fallback to legacy config if MCP config update fails
                     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
                     CONFIG_FILE.write_text(json.dumps({"OPERATIVE_API_KEY": prompted_key}))
-                    send_log(f"{YELLOW}ℹ Could not save API key to MCP config. Saved to legacy config at {CONFIG_FILE} instead.{NC}", "⚠️")
             except Exception as e:
-                send_log(f"{YELLOW}ℹ Could not save API key to MCP config: {e}. Key will not be persisted.{NC}", "⚠️")
+                pass
             
             OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
             return prompted_key
         else:
-            send_log(f"{RED}✗ Validation failed for entered API key: {msg}{NC}", "❌")
-            # Provide a way to exit if user doesn't want to retry
             retry = input("Invalid API key. Would you like to try again? (y/n): ")
             if retry.lower() != 'y':
-                send_log(f"{RED}✗ API key validation failed. Exiting.{NC}", "❌")
                 raise ValueError("Invalid API key and user chose not to retry.")
 
 @mcp.tool(name=BrowserTools.WEB_EVAL_AGENT)
@@ -355,7 +300,6 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         return [TextContent(type="text", text=error_message_str)]
     try:
         tool_call_id = str(uuid.uuid4())
-        send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}", "📝")
         return await handle_setup_browser_state(
             {"url": url, "tool_call_id": tool_call_id},
             ctx,

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -24,12 +24,9 @@ os.environ["ANONYMIZED_TELEMETRY"] = 'false'
 # MCP imports
 from mcp.server.fastmcp import FastMCP, Context
 from mcp.types import TextContent
-# Removing the problematic import
-# from mcp.server.tool import Tool, register_tool
 
 # Import our modules
 from webEvalAgent.src.browser_manager import PlaywrightBrowserManager
-# from webEvalAgent.src.browser_utils import cleanup_resources # Removed import
 from webEvalAgent.src.api_utils import validate_api_key
 from webEvalAgent.src.tool_handlers import handle_web_evaluation, handle_setup_browser_state
 
@@ -47,11 +44,7 @@ mcp = FastMCP("Operative")
 # Define the browser tools
 class BrowserTools(str, Enum):
     WEB_EVAL_AGENT = "web_eval_agent"
-    SETUP_BROWSER_STATE = "setup_browser_state"  # Add new tool enum
-
-# Parse command line arguments (keeping the parser for potential future arguments)
-# parser = argparse.ArgumentParser(description='Run the MCP server with browser debugging capabilities')
-# args = parser.parse_args()
+    SETUP_BROWSER_STATE = "setup_browser_state"
 
 # --- Start of new/modified functions ---
 
@@ -356,7 +349,7 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
         )
     except Exception as e:
         tb = traceback.format_exc()
-        send_log(f"{RED}✗ Error executing web_eval_agent: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌") # Using send_log
+        send_log(f"{RED}✗ Error executing web_eval_agent: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌")
         return [TextContent(
             type="text",
             text=f"Error executing web_eval_agent: {str(e)}\\n\\nTraceback:\\n{tb}"
@@ -398,7 +391,7 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         )
     except Exception as e:
         tb = traceback.format_exc()
-        send_log(f"{RED}✗ Error executing setup_browser_state: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌") # Using send_log
+        send_log(f"{RED}✗ Error executing setup_browser_state: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌")
         return [TextContent(
             type="text",
             text=f"Error executing setup_browser_state: {str(e)}\n\nTraceback:\n{tb}"
@@ -406,13 +399,13 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
 
 def main():
     # Print the ASCII logo
-    print(OPERATIVE_LOGO)
-    print(f"\n{BLUE}{BOLD}=== 🚀 Welcome to the Operative Web Eval Agent ===\n{NC}")
+    send_log(OPERATIVE_LOGO, "🚀")
+    send_log(f"\n{BLUE}{BOLD}=== 🚀 Welcome to the Operative Web Eval Agent ===\n{NC}", "🚀")
     
     try:
         send_log(f"{BOLD}Operative Web Eval Agent starting up...{NC}", "🚀")
         
-        # 0. Determine agent's project path for MCP configuration
+        # Determine agent's project path for MCP configuration
         # Assuming mcp_server.py is in webEvalAgent/ directory, and project root is parent of that.
         # Path(__file__).resolve() gives path to mcp_server.py
         # .parent gives webEvalAgent/
@@ -444,7 +437,7 @@ def main():
                 pass
                 
         # First get and validate API key regardless of configuration state
-        print(f"\n{BLUE}{BOLD}=== API Key Configuration ==={NC}\n")
+        send_log(f"\n{BLUE}{BOLD}=== API Key Configuration ==={NC}\n", "🔑")
         send_log(f"{BOLD}Obtaining and validating API key...{NC}", "🔑")
         operative_key = get_and_validate_api_key()
         if not operative_key:
@@ -455,17 +448,17 @@ def main():
         
         # If not already configured, set up the MCP configuration with the API key
         if not is_already_configured:
-            print(f"\n{BLUE}{BOLD}=== Setting up configuration ==={NC}\n")
+            send_log(f"\n{BLUE}{BOLD}=== Setting up configuration ==={NC}\n", "⚙️")
             # Configure MCP with API key
             _configure_cursor_mcp_json(agent_project_path, operative_key)
 
             # Ensure Playwright browsers are installed
-            print(f"\n{BLUE}{BOLD}=== Checking dependencies ==={NC}\n")
+            send_log(f"\n{BLUE}{BOLD}=== Checking dependencies ==={NC}\n", "🔍")
             send_log(f"{BOLD}Checking for Playwright browser installation...{NC}", "🔍")
             ensure_playwright_browsers()
             
             # Installation complete; instruct user to restart and exit
-            print(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n")
+            send_log(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n", "✅")
             send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
             return
         else:
@@ -483,8 +476,6 @@ def main():
     finally:
         send_log(f"{BOLD}Operative Web Eval Agent shutting down.{NC}", "🏁")
         send_log(f"{BOLD}Built with ❤️ by Operative.sh{NC}", "📝")
-        # Ensure resources are cleaned up
-        # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
 
 if __name__ == "__main__":
     main() # Call the main function which now includes setup.

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -429,17 +429,17 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         list[TextContent]: Confirmation of state saving or error messages.
     """
     api_key = OPERATIVE_API_KEY_HOLDER["key"]
-    is_valid = await validate_api_key(api_key)
+    is_valid, msg = await validate_api_key(api_key)
 
     if not is_valid:
         error_message_str = "❌ Error: API Key validation failed when running the tool.\n"
-        error_message_str += "   Reason: Free tier limit reached.\n"
-        error_message_str += "   👉 Please subscribe at https://operative.sh to continue."
+        error_message_str += f"   Reason: {msg}\n" # Use message from validation
+        error_message_str += "   👉 Please subscribe at https://operative.sh if it's a limit issue."
         return [TextContent(type="text", text=error_message_str)]
     try:
         # Generate a new tool_call_id for this specific tool call
         tool_call_id = str(uuid.uuid4())
-        send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}")
+        send_log(f"Generated new tool_call_id for setup_browser_state: {tool_call_id}", "📝")
         return await handle_setup_browser_state(
             {"url": url, "tool_call_id": tool_call_id},
             ctx,
@@ -447,6 +447,7 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         )
     except Exception as e:
         tb = traceback.format_exc()
+        send_log(f"{RED}✗ Error executing setup_browser_state: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌") # Using send_log
         return [TextContent(
             type="text",
             text=f"Error executing setup_browser_state: {str(e)}\n\nTraceback:\n{tb}"

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -354,7 +354,8 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
                          and screenshots of the web application during the evaluation
     """
     headless = headless_browser
-    is_valid = await validate_api_key(api_key)
+    api_key = OPERATIVE_API_KEY_HOLDER["key"]
+    is_valid, msg = await validate_api_key(api_key)
 
     if not is_valid:
         error_message_str = f"❌ Error: API Key validation failed when running the tool.\\n"
@@ -367,7 +368,7 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
         return await handle_web_evaluation(
             {"url": url, "task": task, "headless": headless, "tool_call_id": tool_call_id},
             ctx,
-            current_api_key # Pass the validated key
+            api_key # Pass the validated key
         )
     except Exception as e:
         tb = traceback.format_exc()
@@ -427,6 +428,7 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
     Returns:
         list[TextContent]: Confirmation of state saving or error messages.
     """
+    api_key = OPERATIVE_API_KEY_HOLDER["key"]
     is_valid = await validate_api_key(api_key)
 
     if not is_valid:

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -518,9 +518,8 @@ def main():
             send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
             return
         else:
-            # We're running in server mode - update MCP config with API key if needed
-            # This updates the key if it's changed since last run
-            cursor_mcp_file, _ = _configure_cursor_mcp_json(agent_project_path, operative_key)
+            # We're running in server mode - don't update MCP config as it's already configured
+            send_log(f"{BOLD}Found existing configuration. Using current settings.{NC}", "📝")
             
             send_log(f"{BOLD}API key validated. Starting MCP server...{NC}", "🛰️")
             # Run the FastMCP server

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -422,10 +422,10 @@ def main():
 
         send_log(f"{BOLD}Using Operative API Key ending with ...{operative_key[-4:] if len(operative_key) > 4 else operative_key}{NC}", "🔑")
         
-        # Run the FastMCP server
+        # Installation complete; instruct user to restart and exit
         print(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n")
-        send_log(f"{BOLD}Starting MCP server...{NC}", "🛰️")
-        mcp.run(transport='stdio')
+        send_log(f"{BOLD}Installation complete. Please restart Cursor for these changes to take effect!{NC}", "⚠️")
+        return
 
     except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
         send_log(f"{RED}✗ Agent startup failed due to API key issue: {e}{NC}", "❌")

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -122,7 +122,7 @@ def _configure_cursor_mcp_json(agent_project_path: Path):
             "command": "uvx",
             "args": [
                 "--from",
-                str(agent_project_path.resolve()), # Use resolved absolute path of the agent project
+                "git+https://github.com/nandatheguntupalli/web-eval-agent.git",
                 "webEvalAgent"
             ],
             "env": {}
@@ -347,7 +347,7 @@ async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Conte
 
 
 def main():
-    print("!!!!!!!!!! WEB EVAL AGENT MCP_SERVER.PY MAIN() HAS STARTED !!!!!!!!!", flush=True)
+    # Startup initiated via send_log; removed loud print statement
     try:
         send_log("Operative Web Eval Agent starting up...", "🚀")
         

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -53,16 +53,50 @@ CONFIG_DIR = Path.home() / ".operative"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 OPERATIVE_API_KEY_HOLDER = {"key": None} # Global holder for the validated API key
 
+# ANSI color and formatting codes
+RED = '\033[0;31m'
+GREEN = '\033[0;32m'
+BLUE = '\033[0;34m'
+YELLOW = '\033[1;33m'
+NC = '\033[0m' # No Color
+BOLD = '\033[1m'
+
+# ASCII Art for startup logo
+OPERATIVE_LOGO = """                                    $$$$                                    
+                                 $$$    $$$                                 
+                              $$$          $$$                              
+                           $$$     $$$$$$     $$$                           
+                        $$$     $$$  $$  $$$     $$$c                       
+                    c$$$     $$$     $$     $$$     $$$$                    
+                   $$$$      $$$x    $$     $$$      $$$$                   
+                   $$  $$$      >$$$ $$ ;$$$      $$$  $$                   
+                   $$     $$$       $$$$8      $$$     $$                   
+                   $$        $$$            $$$        $$                   
+                   $$   $$$     $$$$     $$$     $$$   $$                   
+                   $$   $  $$$     I$$$$$     $$$  $   $$                   
+                   $$   $     $$$    $$    $$$     $   $$                   
+                   $$   $     $$$$   $$   $$$$     $   $$                   
+                   $$   $  $$$   $   $$   $   $$$  $   $$                   
+                   $$   $$$      $   $$   $      $$$   $$                   
+                   $$     $$$    $   $$   $    $$$     $$                   
+                    $$$      $$$ $   $$   $ $$$      $$$                    
+                       $$$      $$   $$   $$      $$$                       
+                          $$$        $$        $$$                          
+                             $$$     $$     $$$                             
+                                $$$  $$  $$$                                
+                                   $$$$$$                                   
+"""
+
 def ensure_playwright_browsers():
     """Checks and installs Playwright browsers if necessary."""
     try:
-        send_log("Checking and installing Playwright browsers if necessary...", "🚀")
+        send_log(f"{BOLD}Checking and installing Playwright browsers if necessary...{NC}", "🚀")
         # Using playwright's Python API to check/install is more robust if available.
         # For now, calling the CLI command.
         # Ensure playwright is in the path for uvx environment.
         process = subprocess.run(["playwright", "install", "--with-deps"], capture_output=True, text=True, check=False, timeout=300)
         if process.returncode == 0:
-            send_log("Playwright browsers are installed/updated.", "✅")
+            send_log(f"{GREEN}✓ Playwright browsers are installed successfully{NC}", "✅")
             if process.stdout:
                 send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
             if process.stderr:
@@ -73,15 +107,15 @@ def ensure_playwright_browsers():
             send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
             # Not raising an error here to allow the agent to attempt to start,
             # but logging a significant warning. Tool usage will likely fail.
-            send_log("Playwright browser installation may have failed. The agent might not function correctly.", "❌")
+            send_log(f"{RED}✗ Playwright browser installation may have failed. The agent might not function correctly.{NC}", "❌")
     except FileNotFoundError:
-        send_log("Playwright command not found. Ensure Playwright is installed in the environment.", "❌")
+        send_log(f"{RED}✗ Playwright command not found. Ensure Playwright is installed in the environment.{NC}", "❌")
         raise Exception("Playwright command not found. Cannot ensure browser installation.")
     except subprocess.TimeoutExpired:
-        send_log("Playwright browser installation timed out after 5 minutes.", "❌")
+        send_log(f"{RED}✗ Playwright browser installation timed out after 5 minutes.{NC}", "❌")
         raise Exception("Playwright browser installation timed out.")
     except Exception as e:
-        send_log(f"Error during Playwright browser setup: {e}", "❌")
+        send_log(f"{RED}✗ Error during Playwright browser setup: {e}{NC}", "❌")
         raise # Re-raise critical errors
 
 def _configure_cursor_mcp_json(agent_project_path: Path):
@@ -89,32 +123,32 @@ def _configure_cursor_mcp_json(agent_project_path: Path):
     cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
     server_name = "web-eval-agent-operative"
     
-    send_log(f"Attempting to configure Cursor MCP server at {cursor_mcp_file}...", "⚙️")
+    send_log(f"{BOLD}Attempting to configure Cursor MCP server at {cursor_mcp_file}...{NC}", "⚙️")
 
     mcp_config = {"mcpServers": {}}
     try:
         if cursor_mcp_file.exists():
-            send_log(f"Found existing Cursor MCP file: {cursor_mcp_file}", "🔍")
+            send_log(f"{YELLOW}ℹ Found existing Cursor MCP file: {cursor_mcp_file}{NC}", "🔍")
             with open(cursor_mcp_file, 'r') as f:
                 try:
                     mcp_config = json.load(f)
                     if not isinstance(mcp_config, dict):
-                        send_log("Cursor MCP file is not a valid JSON object. Reinitializing.", "⚠️")
+                        send_log(f"{YELLOW}ℹ Cursor MCP file is not a valid JSON object. Reinitializing.{NC}", "⚠️")
                         mcp_config = {"mcpServers": {}}
                     if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
-                        send_log("'mcpServers' key missing or invalid in Cursor MCP file. Reinitializing.", "⚠️")
+                        send_log(f"{YELLOW}ℹ 'mcpServers' key missing or invalid in Cursor MCP file. Reinitializing.{NC}", "⚠️")
                         mcp_config["mcpServers"] = {}
                 except json.JSONDecodeError:
-                    send_log(f"Error decoding JSON from {cursor_mcp_file}. Backing up and creating new config.", "⚠️")
+                    send_log(f"{YELLOW}ℹ Error decoding JSON from {cursor_mcp_file}. Backing up and creating new config.{NC}", "⚠️")
                     try:
                         backup_path = cursor_mcp_file.with_suffix(".json.bak")
                         cursor_mcp_file.rename(backup_path)
-                        send_log(f"Backed up corrupted MCP file to {backup_path}", "🛡️")
+                        send_log(f"{BOLD}Backed up corrupted MCP file to {backup_path}{NC}", "🛡️")
                     except OSError as e_backup:
-                        send_log(f"Could not back up corrupted MCP file: {e_backup}", "❌")
+                        send_log(f"{RED}✗ Could not back up corrupted MCP file: {e_backup}{NC}", "❌")
                     mcp_config = {"mcpServers": {}}
         else:
-            send_log(f"Cursor MCP file not found. Creating new one at {cursor_mcp_file}", "📝")
+            send_log(f"{BOLD}Cursor MCP file not found. Creating new one at {cursor_mcp_file}{NC}", "📝")
             # Ensure .cursor directory exists
             cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -131,24 +165,24 @@ def _configure_cursor_mcp_json(agent_project_path: Path):
 
         # Add or update the server entry
         mcp_config["mcpServers"][server_name] = server_config
-        send_log(f"Updating server entry for '{server_name}' in Cursor MCP config.", "🛠️")
+        send_log(f"{BOLD}Updating server entry for '{server_name}' in Cursor MCP config.{NC}", "🛠️")
 
         with open(cursor_mcp_file, 'w') as f:
             json.dump(mcp_config, f, indent=2)
         
-        send_log(f"Successfully updated Cursor MCP configuration at {cursor_mcp_file}.", "✅")
-        send_log("IMPORTANT: Please restart Cursor for these changes to take effect.", "⚠️")
+        send_log(f"{GREEN}✓ Successfully updated Cursor MCP configuration at {cursor_mcp_file}.{NC}", "✅")
+        send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
 
     except OSError as e_os:
-        send_log(f"OS Error updating Cursor MCP file {cursor_mcp_file}: {e_os}", "❌")
-        send_log("Cursor MCP auto-configuration failed. Please configure manually.", "ℹ️")
+        send_log(f"{RED}✗ OS Error updating Cursor MCP file {cursor_mcp_file}: {e_os}{NC}", "❌")
+        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
     except Exception as e_general:
-        send_log(f"Unexpected error during Cursor MCP auto-configuration: {e_general}", "❌")
-        send_log("Cursor MCP auto-configuration failed. Please configure manually.", "ℹ️")
+        send_log(f"{RED}✗ Unexpected error during Cursor MCP auto-configuration: {e_general}{NC}", "❌")
+        send_log(f"{YELLOW}ℹ Cursor MCP auto-configuration failed. Please configure manually.{NC}", "ℹ️")
 
 def _validate_api_key_server_side(api_key_to_validate):
     """Validates API key with the backend server."""
-    send_log("Validating API key with Operative servers...", "➡️")
+    send_log(f"{BOLD}Validating API key with Operative servers...{NC}", "➡️")
     try:
         response = requests.get(
             "https://operative-backend.onrender.com/api/validate-key",
@@ -158,20 +192,20 @@ def _validate_api_key_server_side(api_key_to_validate):
         response.raise_for_status()
         data = response.json()
         if data.get("valid"):
-            send_log("API key validated successfully server-side.", "✅")
+            send_log(f"{GREEN}✓ API key validated successfully server-side.{NC}", "✅")
             return True, data.get("message", "Valid")
         else:
             error_message = data.get("message", "Unknown validation error.")
-            send_log(f"API key validation failed: {error_message}", "❌")
+            send_log(f"{RED}✗ API key validation failed: {error_message}{NC}", "❌")
             return False, error_message
     except requests.exceptions.Timeout:
-        send_log("API key validation timed out.", "❌")
+        send_log(f"{RED}✗ API key validation timed out.{NC}", "❌")
         return False, "Connection to validation server timed out."
     except requests.exceptions.RequestException as e:
-        send_log(f"Could not connect to validation server: {e}", "❌")
+        send_log(f"{RED}✗ Could not connect to validation server: {e}{NC}", "❌")
         return False, f"Could not connect to validation server: {e}"
     except json.JSONDecodeError:
-        send_log("Invalid JSON response from validation server.", "❌")
+        send_log(f"{RED}✗ Invalid JSON response from validation server.{NC}", "❌")
         return False, "Invalid JSON response from validation server."
 
 def get_and_validate_api_key():
@@ -180,7 +214,7 @@ def get_and_validate_api_key():
     source = "environment variable"
 
     if not api_key:
-        send_log("API key not found in environment variables. Checking local config...", "🔍")
+        send_log(f"{YELLOW}ℹ API key not found in environment variables. Checking local config...{NC}", "🔍")
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         if CONFIG_FILE.exists():
             try:
@@ -188,32 +222,33 @@ def get_and_validate_api_key():
                 api_key = config_data.get("OPERATIVE_API_KEY")
                 source = "local config file"
             except json.JSONDecodeError:
-                send_log(f"Error reading local API key config file ({CONFIG_FILE}). File might be corrupted.", "⚠️")
+                send_log(f"{YELLOW}ℹ Error reading local API key config file ({CONFIG_FILE}). File might be corrupted.{NC}", "⚠️")
                 api_key = None # Ensure api_key is None if file is corrupt
         
     if api_key:
-        send_log(f"API key found in {source}.", "📝")
+        send_log(f"{YELLOW}ℹ API key found in {source}.{NC}", "📝")
         is_valid, msg = _validate_api_key_server_side(api_key)
         if is_valid:
             OPERATIVE_API_KEY_HOLDER["key"] = api_key
             return api_key
         else:
-            send_log(f"Invalid API key from {source}: {msg}. Will prompt user.", "⚠️")
+            send_log(f"{YELLOW}ℹ Invalid API key from {source}: {msg}. Will prompt user.{NC}", "⚠️")
             api_key = None # Reset api_key to trigger prompt
 
     # Prompt user if no valid key found yet
     while True:
-        send_log("Operative API Key is required.", "🔑")
+        send_log(f"{BOLD}An Operative.sh API key is required for this installation.{NC}", "🔑")
+        send_log(f"If you don't have one, please visit {BOLD}https://operative.sh{NC} to get your key.", "🔑")
         # This input method might not work reliably when run as a background MCP server.
         # A more robust solution (e.g., a first-run setup UI or command) might be needed for some MCP clients.
         try:
             prompted_key = input("Please enter your Operative.sh API key: ")
         except EOFError: # Happens if stdin is not available (e.g. background process)
-             send_log("Could not read API key from input (EOFError). Ensure OPERATIVE_API_KEY is set in the environment or ~/.operative/config.json", "❌")
+             send_log(f"{RED}✗ Could not read API key from input (EOFError). Ensure OPERATIVE_API_KEY is set in the environment or ~/.operative/config.json{NC}", "❌")
              raise ValueError("API Key could not be obtained via input. Configure it via environment or local file.")
 
         if not prompted_key:
-            send_log("API key cannot be empty. Please try again.", "❌")
+            send_log(f"{RED}✗ API key cannot be empty. Please try again.{NC}", "❌")
             continue
         
         is_valid, msg = _validate_api_key_server_side(prompted_key)
@@ -221,17 +256,17 @@ def get_and_validate_api_key():
             try:
                 CONFIG_DIR.mkdir(parents=True, exist_ok=True) # Ensure dir exists again
                 CONFIG_FILE.write_text(json.dumps({"OPERATIVE_API_KEY": prompted_key}))
-                send_log(f"API key validated and saved to {CONFIG_FILE}", "✅")
+                send_log(f"{GREEN}✓ API key validated and saved to {CONFIG_FILE}{NC}", "✅")
             except IOError as e:
-                send_log(f"Could not save API key to {CONFIG_FILE}: {e}. Key will not be persisted.", "⚠️")
+                send_log(f"{YELLOW}ℹ Could not save API key to {CONFIG_FILE}: {e}. Key will not be persisted.{NC}", "⚠️")
             OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
             return prompted_key
         else:
-            send_log(f"Validation failed for entered API key: {msg}", "❌")
+            send_log(f"{RED}✗ Validation failed for entered API key: {msg}{NC}", "❌")
             # Provide a way to exit if user doesn't want to retry
             retry = input("Invalid API key. Would you like to try again? (y/n): ")
             if retry.lower() != 'y':
-                send_log("API key validation failed. Exiting.", "❌")
+                send_log(f"{RED}✗ API key validation failed. Exiting.{NC}", "❌")
                 raise ValueError("Invalid API key and user chose not to retry.")
 
 # --- End of new/modified functions ---
@@ -279,7 +314,7 @@ async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Conte
     current_api_key = OPERATIVE_API_KEY_HOLDER.get("key")
     if not current_api_key:
         # This should ideally not happen if main() enforced key validation.
-        send_log("API key not available in tool function. This indicates a setup issue.", "❌")
+        send_log(f"{RED}✗ API key not available in tool function. This indicates a setup issue.{NC}", "❌")
         return [TextContent(type="text", text="❌ Error: Operative API Key is missing or was not validated during startup.")]
 
     # Re-validate the key or rely on the initial validation? 
@@ -298,7 +333,7 @@ async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Conte
     try:
         # Generate a new tool_call_id for this specific tool call
         tool_call_id = str(uuid.uuid4())
-        send_log(f"Generated new tool_call_id for web_eval_agent: {tool_call_id}", "🆔") # Using send_log
+        send_log(f"{BOLD}Generated new tool_call_id for web_eval_agent: {tool_call_id}{NC}", "🆔") # Using send_log
         return await handle_web_evaluation(
             {"url": url, "task": task, "headless": headless, "tool_call_id": tool_call_id},
             ctx,
@@ -306,7 +341,7 @@ async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Conte
         )
     except Exception as e:
         tb = traceback.format_exc()
-        send_log(f"Error executing web_eval_agent: {str(e)}\\nTraceback:\\n{tb}", "❌") # Using send_log
+        send_log(f"{RED}✗ Error executing web_eval_agent: {str(e)}\\nTraceback:\\n{tb}{NC}", "❌") # Using send_log
         return [TextContent(
             type="text",
             text=f"Error executing web_eval_agent: {str(e)}\\n\\nTraceback:\\n{tb}"
@@ -347,9 +382,12 @@ async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Conte
 
 
 def main():
-    # Startup initiated via send_log; removed loud print statement
+    # Print the ASCII logo
+    print(OPERATIVE_LOGO)
+    print(f"\n{BLUE}{BOLD}=== 🚀 Welcome to the Operative Web Eval Agent ===\n{NC}")
+    
     try:
-        send_log("Operative Web Eval Agent starting up...", "🚀")
+        send_log(f"{BOLD}Operative Web Eval Agent starting up...{NC}", "🚀")
         
         # 0. Determine agent's project path for MCP configuration
         # Assuming mcp_server.py is in webEvalAgent/ directory, and project root is parent of that.
@@ -361,34 +399,41 @@ def main():
         except NameError: # __file__ not defined (e.g. in interactive interpreter or frozen app)
             # Fallback to current working directory, might not always be correct if script is run from elsewhere
             agent_project_path = Path(".").resolve()
-            send_log(f"Could not determine agent script path via __file__, falling back to CWD: {agent_project_path}", "⚠️")
+            send_log(f"{YELLOW}ℹ Could not determine agent script path via __file__, falling back to CWD: {agent_project_path}{NC}", "⚠️")
 
         # Attempt to configure Cursor MCP
+        print(f"\n{BLUE}{BOLD}=== Setting up configuration ==={NC}\n")
         _configure_cursor_mcp_json(agent_project_path)
 
         # 1. Ensure Playwright browsers are installed
+        print(f"\n{BLUE}{BOLD}=== Checking dependencies ==={NC}\n")
+        send_log(f"{BOLD}Checking for Playwright browser installation...{NC}", "🔍")
         ensure_playwright_browsers()
         
         # 2. Get and validate API key
         # This will prompt if not found in env or local config.
         # The validated key is stored in OPERATIVE_API_KEY_HOLDER["key"]
+        print(f"\n{BLUE}{BOLD}=== API Key Configuration ==={NC}\n")
+        send_log(f"{BOLD}Obtaining and validating API key...{NC}", "🔑")
         operative_key = get_and_validate_api_key()
         if not operative_key: # Should not happen if get_and_validate_api_key raises on failure
-            send_log("Critical: Operative API key could not be obtained or validated. Exiting.", "❌")
+            send_log(f"{RED}✗ Critical: Operative API key could not be obtained or validated. Exiting.{NC}", "❌")
             return # Exit if no key
 
-        send_log(f"Using Operative API Key ending with ...{operative_key[-4:] if len(operative_key) > 4 else operative_key}", "🔑")
+        send_log(f"{BOLD}Using Operative API Key ending with ...{operative_key[-4:] if len(operative_key) > 4 else operative_key}{NC}", "🔑")
         
         # Run the FastMCP server
-        send_log("Starting MCP server...", "🛰️")
+        print(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n")
+        send_log(f"{BOLD}Starting MCP server...{NC}", "🛰️")
         mcp.run(transport='stdio')
 
     except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
-        send_log(f"Agent startup failed due to API key issue: {e}", "❌")
+        send_log(f"{RED}✗ Agent startup failed due to API key issue: {e}{NC}", "❌")
     except Exception as e:
-        send_log(f"An unexpected error occurred during agent startup: {e}\n{traceback.format_exc()}", "❌")
+        send_log(f"{RED}✗ An unexpected error occurred during agent startup: {e}\n{traceback.format_exc()}{NC}", "❌")
     finally:
-        send_log("Operative Web Eval Agent shutting down.", "🏁")
+        send_log(f"{BOLD}Operative Web Eval Agent shutting down.{NC}", "🏁")
+        send_log(f"{BOLD}Built with ❤️ by Operative.sh{NC}", "📝")
         # Ensure resources are cleaned up
         # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
 

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -355,11 +355,11 @@ async def web_eval_agent(url: str, task: str, ctx: Context, headless_browser: bo
     """
     headless = headless_browser
     api_key = OPERATIVE_API_KEY_HOLDER["key"]
-    is_valid, msg = await validate_api_key(api_key)
+    is_valid = await validate_api_key(api_key)
 
     if not is_valid:
         error_message_str = f"❌ Error: API Key validation failed when running the tool.\\n"
-        error_message_str += f"   Reason: {msg}\\n" # Use message from validation
+        error_message_str += f"   Reason: Invalid API key or usage limit reached.\\n"
         error_message_str += "   👉 Please check your API key or subscribe at https://operative.sh if it's a limit issue."
         return [TextContent(type="text", text=error_message_str)]
     try:
@@ -429,11 +429,11 @@ async def setup_browser_state(url: str = None, ctx: Context = None) -> list[Text
         list[TextContent]: Confirmation of state saving or error messages.
     """
     api_key = OPERATIVE_API_KEY_HOLDER["key"]
-    is_valid, msg = await validate_api_key(api_key)
+    is_valid = await validate_api_key(api_key)
 
     if not is_valid:
         error_message_str = "❌ Error: API Key validation failed when running the tool.\n"
-        error_message_str += f"   Reason: {msg}\n" # Use message from validation
+        error_message_str += "   Reason: Invalid API key or usage limit reached.\n"
         error_message_str += "   👉 Please subscribe at https://operative.sh if it's a limit issue."
         return [TextContent(type="text", text=error_message_str)]
     try:

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -481,7 +481,7 @@ def main():
             
             # Installation complete; instruct user to restart and exit
             print(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n")
-            send_log(f"{BOLD}Installation complete. Please restart Cursor for these changes to take effect!{NC}", "⚠️")
+            send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
             return
         else:
             # We're running in server mode - update MCP config with API key if needed

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -281,22 +281,6 @@ def get_and_validate_api_key():
         
         is_valid, msg = _validate_api_key_server_side(prompted_key)
         if is_valid:
-            # Save API key to MCP config
-            cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
-            server_name = "web-eval-agent-operative"
-            try:
-                # Update MCP config with API key
-                mcp_file, mcp_config = _configure_cursor_mcp_json(Path(".").resolve(), prompted_key)
-                if mcp_file:
-                    send_log(f"{GREEN}✓ API key validated and saved to MCP config at {mcp_file}{NC}", "✅")
-                else:
-                    # Fallback to legacy config if MCP config update fails
-                    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-                    CONFIG_FILE.write_text(json.dumps({"OPERATIVE_API_KEY": prompted_key}))
-                    send_log(f"{YELLOW}ℹ Could not save API key to MCP config. Saved to legacy config at {CONFIG_FILE} instead.{NC}", "⚠️")
-            except Exception as e:
-                send_log(f"{YELLOW}ℹ Could not save API key to MCP config: {e}. Key will not be persisted.{NC}", "⚠️")
-            
             OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
             return prompted_key
         else:
@@ -468,29 +452,9 @@ def main():
             
         send_log(f"{BOLD}Using Operative API Key ending with ...{operative_key[-4:] if len(operative_key) > 4 else operative_key}{NC}", "🔑")
         
-        # If not already configured, set up the MCP configuration with the API key
-        if not is_already_configured:
-            print(f"\n{BLUE}{BOLD}=== Setting up configuration ==={NC}\n")
-            # Configure MCP with API key
-            _configure_cursor_mcp_json(agent_project_path, operative_key)
-
-            # Ensure Playwright browsers are installed
-            print(f"\n{BLUE}{BOLD}=== Checking dependencies ==={NC}\n")
-            send_log(f"{BOLD}Checking for Playwright browser installation...{NC}", "🔍")
-            ensure_playwright_browsers()
-            
-            # Installation complete; instruct user to restart and exit
-            print(f"\n{BLUE}{BOLD}=== Installation Complete! 🎉 ==={NC}\n")
-            send_log(f"{RED}{BOLD}⚠️ IMPORTANT: Please restart Cursor for these changes to take effect!{NC}", "⚠️")
-            return
-        else:
-            # We're running in server mode - update MCP config with API key if needed
-            # This updates the key if it's changed since last run
-            cursor_mcp_file, _ = _configure_cursor_mcp_json(agent_project_path, operative_key)
-            
-            send_log(f"{BOLD}API key validated. Starting MCP server...{NC}", "🛰️")
-            # Run the FastMCP server
-            mcp.run(transport='stdio')
+        # Start the MCP server
+        send_log(f"{BOLD}API key validated. Starting MCP server...{NC}", "🛰️")
+        mcp.run(transport='stdio')
 
     except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
         send_log(f"{RED}✗ Agent startup failed due to API key issue: {e}{NC}", "❌")

--- a/webEvalAgent/mcp_server.py
+++ b/webEvalAgent/mcp_server.py
@@ -6,7 +6,19 @@ import argparse
 import traceback
 import uuid
 from enum import Enum
+import subprocess
+import json
+from pathlib import Path
+import requests
+
 from webEvalAgent.src.utils import stop_log_server
+# Assuming send_log is available here, adjust if necessary
+from webEvalAgent.src.log_server import send_log # Placeholder, ensure this is correct
+
+# Placeholder for send_log if not correctly imported above.
+# If you have a central logging setup, use that. Otherwise, this is a basic fallback.
+# def send_log(message, emoji=""):
+#     print(f"{emoji} {message}")
 
 # Set the API key to a fake key to avoid error in backend
 os.environ["ANTHROPIC_API_KEY"] = 'not_a_real_key'
@@ -19,7 +31,7 @@ from mcp.types import TextContent
 # Import our modules
 from webEvalAgent.src.browser_manager import PlaywrightBrowserManager
 # from webEvalAgent.src.browser_utils import cleanup_resources # Removed import
-from webEvalAgent.src.api_utils import validate_api_key
+from webEvalAgent.src.api_utils import validate_api_key as validate_api_key_original # Renamed to avoid conflict
 from webEvalAgent.src.tool_handlers import handle_web_evaluation
 
 stop_log_server() # Stop the log server before starting the MCP server
@@ -32,19 +44,211 @@ class BrowserTools(str, Enum):
     WEB_EVAL_AGENT = "web_eval_agent"
 
 # Parse command line arguments (keeping the parser for potential future arguments)
-parser = argparse.ArgumentParser(description='Run the MCP server with browser debugging capabilities')
-args = parser.parse_args()
+# parser = argparse.ArgumentParser(description='Run the MCP server with browser debugging capabilities')
+# args = parser.parse_args()
+
+# --- Start of new/modified functions ---
+
+CONFIG_DIR = Path.home() / ".operative"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+OPERATIVE_API_KEY_HOLDER = {"key": None} # Global holder for the validated API key
+
+def ensure_playwright_browsers():
+    """Checks and installs Playwright browsers if necessary."""
+    try:
+        send_log("Checking and installing Playwright browsers if necessary...", "🚀")
+        # Using playwright's Python API to check/install is more robust if available.
+        # For now, calling the CLI command.
+        # Ensure playwright is in the path for uvx environment.
+        process = subprocess.run(["playwright", "install", "--with-deps"], capture_output=True, text=True, check=False, timeout=300)
+        if process.returncode == 0:
+            send_log("Playwright browsers are installed/updated.", "✅")
+            if process.stdout:
+                send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
+            if process.stderr:
+                send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
+        else:
+            send_log(f"Playwright browser installation command finished with code {process.returncode}.", "⚠️")
+            send_log(f"Playwright install STDOUT: {process.stdout.strip()}", "⚙️")
+            send_log(f"Playwright install STDERR: {process.stderr.strip()}", "⚙️")
+            # Not raising an error here to allow the agent to attempt to start,
+            # but logging a significant warning. Tool usage will likely fail.
+            send_log("Playwright browser installation may have failed. The agent might not function correctly.", "❌")
+    except FileNotFoundError:
+        send_log("Playwright command not found. Ensure Playwright is installed in the environment.", "❌")
+        raise Exception("Playwright command not found. Cannot ensure browser installation.")
+    except subprocess.TimeoutExpired:
+        send_log("Playwright browser installation timed out after 5 minutes.", "❌")
+        raise Exception("Playwright browser installation timed out.")
+    except Exception as e:
+        send_log(f"Error during Playwright browser setup: {e}", "❌")
+        raise # Re-raise critical errors
+
+def _configure_cursor_mcp_json(agent_project_path: Path):
+    """Attempts to automatically configure Cursor's mcp.json file."""
+    cursor_mcp_file = Path.home() / ".cursor" / "mcp.json"
+    server_name = "web-eval-agent-operative"
+    
+    send_log(f"Attempting to configure Cursor MCP server at {cursor_mcp_file}...", "⚙️")
+
+    mcp_config = {"mcpServers": {}}
+    try:
+        if cursor_mcp_file.exists():
+            send_log(f"Found existing Cursor MCP file: {cursor_mcp_file}", "🔍")
+            with open(cursor_mcp_file, 'r') as f:
+                try:
+                    mcp_config = json.load(f)
+                    if not isinstance(mcp_config, dict):
+                        send_log("Cursor MCP file is not a valid JSON object. Reinitializing.", "⚠️")
+                        mcp_config = {"mcpServers": {}}
+                    if "mcpServers" not in mcp_config or not isinstance(mcp_config.get("mcpServers"), dict):
+                        send_log("'mcpServers' key missing or invalid in Cursor MCP file. Reinitializing.", "⚠️")
+                        mcp_config["mcpServers"] = {}
+                except json.JSONDecodeError:
+                    send_log(f"Error decoding JSON from {cursor_mcp_file}. Backing up and creating new config.", "⚠️")
+                    try:
+                        backup_path = cursor_mcp_file.with_suffix(".json.bak")
+                        cursor_mcp_file.rename(backup_path)
+                        send_log(f"Backed up corrupted MCP file to {backup_path}", "🛡️")
+                    except OSError as e_backup:
+                        send_log(f"Could not back up corrupted MCP file: {e_backup}", "❌")
+                    mcp_config = {"mcpServers": {}}
+        else:
+            send_log(f"Cursor MCP file not found. Creating new one at {cursor_mcp_file}", "📝")
+            # Ensure .cursor directory exists
+            cursor_mcp_file.parent.mkdir(parents=True, exist_ok=True)
+
+        server_config = {
+            "command": "uvx",
+            "args": [
+                "--from",
+                str(agent_project_path.resolve()), # Use resolved absolute path of the agent project
+                "webEvalAgent"
+            ],
+            "env": {}
+            # API key is handled by the agent itself now, so not explicitly set here.
+        }
+
+        # Add or update the server entry
+        mcp_config["mcpServers"][server_name] = server_config
+        send_log(f"Updating server entry for '{server_name}' in Cursor MCP config.", "🛠️")
+
+        with open(cursor_mcp_file, 'w') as f:
+            json.dump(mcp_config, f, indent=2)
+        
+        send_log(f"Successfully updated Cursor MCP configuration at {cursor_mcp_file}.", "✅")
+        send_log("IMPORTANT: Please restart Cursor for these changes to take effect.", "⚠️")
+
+    except OSError as e_os:
+        send_log(f"OS Error updating Cursor MCP file {cursor_mcp_file}: {e_os}", "❌")
+        send_log("Cursor MCP auto-configuration failed. Please configure manually.", "ℹ️")
+    except Exception as e_general:
+        send_log(f"Unexpected error during Cursor MCP auto-configuration: {e_general}", "❌")
+        send_log("Cursor MCP auto-configuration failed. Please configure manually.", "ℹ️")
+
+def _validate_api_key_server_side(api_key_to_validate):
+    """Validates API key with the backend server."""
+    send_log("Validating API key with Operative servers...", "➡️")
+    try:
+        response = requests.get(
+            "https://operative-backend.onrender.com/api/validate-key",
+            headers={"x-operative-api-key": api_key_to_validate},
+            timeout=15
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data.get("valid"):
+            send_log("API key validated successfully server-side.", "✅")
+            return True, data.get("message", "Valid")
+        else:
+            error_message = data.get("message", "Unknown validation error.")
+            send_log(f"API key validation failed: {error_message}", "❌")
+            return False, error_message
+    except requests.exceptions.Timeout:
+        send_log("API key validation timed out.", "❌")
+        return False, "Connection to validation server timed out."
+    except requests.exceptions.RequestException as e:
+        send_log(f"Could not connect to validation server: {e}", "❌")
+        return False, f"Could not connect to validation server: {e}"
+    except json.JSONDecodeError:
+        send_log("Invalid JSON response from validation server.", "❌")
+        return False, "Invalid JSON response from validation server."
+
+def get_and_validate_api_key():
+    """Gets API key from env, local config, or prompts user, then validates and stores it."""
+    api_key = os.environ.get("OPERATIVE_API_KEY")
+    source = "environment variable"
+
+    if not api_key:
+        send_log("API key not found in environment variables. Checking local config...", "🔍")
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        if CONFIG_FILE.exists():
+            try:
+                config_data = json.loads(CONFIG_FILE.read_text())
+                api_key = config_data.get("OPERATIVE_API_KEY")
+                source = "local config file"
+            except json.JSONDecodeError:
+                send_log(f"Error reading local API key config file ({CONFIG_FILE}). File might be corrupted.", "⚠️")
+                api_key = None # Ensure api_key is None if file is corrupt
+        
+    if api_key:
+        send_log(f"API key found in {source}.", "📝")
+        is_valid, msg = _validate_api_key_server_side(api_key)
+        if is_valid:
+            OPERATIVE_API_KEY_HOLDER["key"] = api_key
+            return api_key
+        else:
+            send_log(f"Invalid API key from {source}: {msg}. Will prompt user.", "⚠️")
+            api_key = None # Reset api_key to trigger prompt
+
+    # Prompt user if no valid key found yet
+    while True:
+        send_log("Operative API Key is required.", "🔑")
+        # This input method might not work reliably when run as a background MCP server.
+        # A more robust solution (e.g., a first-run setup UI or command) might be needed for some MCP clients.
+        try:
+            prompted_key = input("Please enter your Operative.sh API key: ")
+        except EOFError: # Happens if stdin is not available (e.g. background process)
+             send_log("Could not read API key from input (EOFError). Ensure OPERATIVE_API_KEY is set in the environment or ~/.operative/config.json", "❌")
+             raise ValueError("API Key could not be obtained via input. Configure it via environment or local file.")
+
+        if not prompted_key:
+            send_log("API key cannot be empty. Please try again.", "❌")
+            continue
+        
+        is_valid, msg = _validate_api_key_server_side(prompted_key)
+        if is_valid:
+            try:
+                CONFIG_DIR.mkdir(parents=True, exist_ok=True) # Ensure dir exists again
+                CONFIG_FILE.write_text(json.dumps({"OPERATIVE_API_KEY": prompted_key}))
+                send_log(f"API key validated and saved to {CONFIG_FILE}", "✅")
+            except IOError as e:
+                send_log(f"Could not save API key to {CONFIG_FILE}: {e}. Key will not be persisted.", "⚠️")
+            OPERATIVE_API_KEY_HOLDER["key"] = prompted_key
+            return prompted_key
+        else:
+            send_log(f"Validation failed for entered API key: {msg}", "❌")
+            # Provide a way to exit if user doesn't want to retry
+            retry = input("Invalid API key. Would you like to try again? (y/n): ")
+            if retry.lower() != 'y':
+                send_log("API key validation failed. Exiting.", "❌")
+                raise ValueError("Invalid API key and user chose not to retry.")
+
+# --- End of new/modified functions ---
 
 # Get API key from environment variable
-api_key = os.environ.get('OPERATIVE_API_KEY')
+# This initial check is now handled by get_and_validate_api_key() in main()
+# api_key = os.environ.get('OPERATIVE_API_KEY') 
 
 # Validate the API key
-if api_key:
-    is_valid = asyncio.run(validate_api_key(api_key))
-    if not is_valid:
-        print("Error: Invalid API key. Please provide a valid OperativeAI API key in the OPERATIVE_API_KEY environment variable.")
-else:
-    print("Error: No API key provided. Please set the OPERATIVE_API_KEY environment variable.")
+# This initial validation is now handled by get_and_validate_api_key() in main()
+# if api_key:
+#     is_valid = asyncio.run(validate_api_key_original(api_key)) # Use renamed original
+#     if not is_valid:
+#         print("Error: Invalid API key. Please provide a valid OperativeAI API key in the OPERATIVE_API_KEY environment variable.")
+# else:
+#     print("Error: No API key provided. Please set the OPERATIVE_API_KEY environment variable.")
+
 
 @mcp.tool(name=BrowserTools.WEB_EVAL_AGENT)
 async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Context) -> list[TextContent]:
@@ -71,54 +275,122 @@ async def web_eval_agent(url: str, task: str, working_directory: str, ctx: Conte
     external_browser = False
     # Convert external_browser to headless parameter (inverse logic)
     headless = not external_browser
-    is_valid = await validate_api_key(api_key)
+    
+    current_api_key = OPERATIVE_API_KEY_HOLDER.get("key")
+    if not current_api_key:
+        # This should ideally not happen if main() enforced key validation.
+        send_log("API key not available in tool function. This indicates a setup issue.", "❌")
+        return [TextContent(type="text", text="❌ Error: Operative API Key is missing or was not validated during startup.")]
+
+    # Re-validate the key or rely on the initial validation? 
+    # The original code re-validates here using validate_api_key_original.
+    # For simplicity and to trust the startup validation, we can use the stored key.
+    # However, if the key could become invalid server-side during a long session, re-validation might be desired.
+    # Let's stick to the new server-side validation for consistency if we re-validate.
+    
+    is_valid, msg = await asyncio.to_thread(_validate_api_key_server_side, current_api_key)
 
     if not is_valid:
-        error_message_str = "❌ Error: API Key validation failed when running the tool.\n"
-        error_message_str += "   Reason: Free tier limit reached.\n"
-        error_message_str += "   👉 Please subscribe at https://operative.sh to continue."
+        error_message_str = f"❌ Error: API Key validation failed when running the tool.\\n"
+        error_message_str += f"   Reason: {msg}\\n" # Use message from validation
+        error_message_str += "   👉 Please check your API key or subscribe at https://operative.sh if it's a limit issue."
         return [TextContent(type="text", text=error_message_str)]
     try:
         # Generate a new tool_call_id for this specific tool call
         tool_call_id = str(uuid.uuid4())
-        print(f"Generated new tool_call_id for web_eval_agent: {tool_call_id}")
+        send_log(f"Generated new tool_call_id for web_eval_agent: {tool_call_id}", "🆔") # Using send_log
         return await handle_web_evaluation(
             {"url": url, "task": task, "headless": headless, "tool_call_id": tool_call_id},
             ctx,
-            api_key
+            current_api_key # Pass the validated key
         )
     except Exception as e:
         tb = traceback.format_exc()
+        send_log(f"Error executing web_eval_agent: {str(e)}\\nTraceback:\\n{tb}", "❌") # Using send_log
         return [TextContent(
             type="text",
-            text=f"Error executing web_eval_agent: {str(e)}\n\nTraceback:\n{tb}"
+            text=f"Error executing web_eval_agent: {str(e)}\\n\\nTraceback:\\n{tb}"
         )]
 
-if __name__ == "__main__":
-    try:
-        # Run a test evaluation on localhost:5173
-        import asyncio
+# if __name__ == "__main__": # Keep this for direct testing if needed, but ensure API key is handled.
+#     try:
+#         # Ensure setup for direct run
+#         ensure_playwright_browsers()
+#         OPERATIVE_API_KEY_HOLDER["key"] = get_and_validate_api_key() # Ensures key for direct run
         
-        async def run_test_eval():
-            await web_eval_agent(
-                url="http://localhost:5173", 
-                task="general eval", 
-                working_directory=".", 
-                ctx="fdafdaf"
-            )
+#         send_log(f"Running test evaluation with key: {OPERATIVE_API_KEY_HOLDER['key']}", "🧪")
+
+#         async def run_test_eval():
+#             # Need a dummy Context object for direct testing
+#             class DummyContext:
+#                 async def send_chunk(self, content):
+#                     send_log(f"DummyContext chunk: {content}", "📦")
+#                 async def send_message(self, message_type, content):
+#                     send_log(f"DummyContext message ({message_type}): {content}", "📦")
+            
+#             await web_eval_agent(
+#                 url="http://localhost:5173", 
+#                 task="general eval", 
+#                 working_directory=".", 
+#                 ctx=DummyContext() # Pass a dummy context
+#             )
         
-        # Run the evaluation
-        asyncio.run(run_test_eval())
-    finally:
-        # Ensure resources are cleaned up
-        # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
-        pass # Keep finally block structure if needed later
+#         asyncio.run(run_test_eval())
+#     except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
+#         send_log(f"Setup for direct run failed: {e}", "❌")
+#     except Exception as e:
+#         send_log(f"Error during direct test run: {e}\n{traceback.format_exc()}", "❌")
+#     finally:
+#         # Ensure resources are cleaned up
+#         # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
+#         send_log("Direct test run finished.", "🏁")
+
 
 def main():
-     try:
-         # Run the FastMCP server
-         mcp.run(transport='stdio')
-     finally:
-         # Ensure resources are cleaned up
-         # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
-         pass # Keep finally block structure if needed later
+    print("!!!!!!!!!! WEB EVAL AGENT MCP_SERVER.PY MAIN() HAS STARTED !!!!!!!!!", flush=True)
+    try:
+        send_log("Operative Web Eval Agent starting up...", "🚀")
+        
+        # 0. Determine agent's project path for MCP configuration
+        # Assuming mcp_server.py is in webEvalAgent/ directory, and project root is parent of that.
+        # Path(__file__).resolve() gives path to mcp_server.py
+        # .parent gives webEvalAgent/
+        # .parent again gives the project root.
+        try:
+            agent_project_path = Path(__file__).resolve().parent.parent
+        except NameError: # __file__ not defined (e.g. in interactive interpreter or frozen app)
+            # Fallback to current working directory, might not always be correct if script is run from elsewhere
+            agent_project_path = Path(".").resolve()
+            send_log(f"Could not determine agent script path via __file__, falling back to CWD: {agent_project_path}", "⚠️")
+
+        # Attempt to configure Cursor MCP
+        _configure_cursor_mcp_json(agent_project_path)
+
+        # 1. Ensure Playwright browsers are installed
+        ensure_playwright_browsers()
+        
+        # 2. Get and validate API key
+        # This will prompt if not found in env or local config.
+        # The validated key is stored in OPERATIVE_API_KEY_HOLDER["key"]
+        operative_key = get_and_validate_api_key()
+        if not operative_key: # Should not happen if get_and_validate_api_key raises on failure
+            send_log("Critical: Operative API key could not be obtained or validated. Exiting.", "❌")
+            return # Exit if no key
+
+        send_log(f"Using Operative API Key ending with ...{operative_key[-4:] if len(operative_key) > 4 else operative_key}", "🔑")
+        
+        # Run the FastMCP server
+        send_log("Starting MCP server...", "🛰️")
+        mcp.run(transport='stdio')
+
+    except ValueError as e: # Catch API key validation errors from get_and_validate_api_key
+        send_log(f"Agent startup failed due to API key issue: {e}", "❌")
+    except Exception as e:
+        send_log(f"An unexpected error occurred during agent startup: {e}\n{traceback.format_exc()}", "❌")
+    finally:
+        send_log("Operative Web Eval Agent shutting down.", "🏁")
+        # Ensure resources are cleaned up
+        # asyncio.run(cleanup_resources()) # Cleanup now handled in browser_utils
+
+if __name__ == "__main__":
+    main() # Call the main function which now includes setup.

--- a/webEvalAgent/src/browser_utils.py
+++ b/webEvalAgent/src/browser_utils.py
@@ -19,9 +19,6 @@ from .log_server import send_log
 # Import Playwright types
 from playwright.async_api import async_playwright, Error as PlaywrightError, Browser as PlaywrightBrowser, BrowserContext as PlaywrightBrowserContext, Page as PlaywrightPage
 
-# Local imports (assuming browser_manager is potentially still used for singleton logic elsewhere, or can be removed if fully replaced)
-# from browser_manager import PlaywrightBrowserManager # Commented out if not needed
-
 # Browser-use imports
 from browser_use.agent.service import Agent
 from browser_use.browser.browser import Browser, BrowserConfig
@@ -38,8 +35,6 @@ _original_bring_to_front = None
 # This prevents the browser window from stealing focus during execution.
 async def _no_bring_to_front(self, *args, **kwargs):
     return None
-
-# We'll apply and remove the patch in run_browser_task
 
 # Global variables
 agent_instance = None  # Store agent instance

--- a/webEvalAgent/src/log_server.py
+++ b/webEvalAgent/src/log_server.py
@@ -102,10 +102,10 @@ def handle_disconnect():
 
 def send_log(message: str, emoji: str = "➡️", log_type: str = 'agent'):
     """Sends a log message with an emoji prefix and type to all connected clients."""
-    # Ensure socketio context is available. If called from a non-SocketIO thread,
-    # use socketio.emit directly.
     try:
         log_entry = f"{emoji} {message}"
+        # Also output logs to terminal for user-friendly CLI experience
+        print(log_entry, flush=True)
         # Include log_type in the emitted data
         socketio.emit('log_message', {'data': log_entry, 'type': log_type})
     except Exception:

--- a/webEvalAgent/src/log_server.py
+++ b/webEvalAgent/src/log_server.py
@@ -8,6 +8,7 @@ from flask_socketio import SocketIO
 import logging
 import os
 from datetime import datetime
+import json
 
 # Track active dashboard tabs
 active_dashboard_tabs = {}
@@ -101,13 +102,17 @@ def handle_disconnect():
         pass
 
 def send_log(message: str, emoji: str = "➡️", log_type: str = 'agent'):
-    """Sends a log message with an emoji prefix and type to all connected clients."""
+    """Sends a log message with an emoji prefix and type to all connected clients as a JSON string."""
     try:
-        log_entry = f"{emoji} {message}"
-        # Also output logs to terminal for user-friendly CLI experience
-        print(log_entry, flush=True)
-        # Include log_type in the emitted data
-        socketio.emit('log_message', {'data': log_entry, 'type': log_type})
+        log_entry = {
+            "message": message,
+            "emoji": emoji,
+            "type": log_type
+        }
+        # Output logs to terminal for user-friendly CLI experience
+        print(f"{emoji} {message}", flush=True)
+        # Emit as a JSON string to ensure valid JSON is sent
+        socketio.emit('log_message', json.dumps(log_entry, ensure_ascii=False))
     except Exception:
         pass
 

--- a/webEvalAgent/src/log_server.py
+++ b/webEvalAgent/src/log_server.py
@@ -102,17 +102,13 @@ def handle_disconnect():
         pass
 
 def send_log(message: str, emoji: str = "➡️", log_type: str = 'agent'):
-    """Sends a log message with an emoji prefix and type to all connected clients as a JSON string."""
+    """Send a log message with an emoji prefix and type to all connected clients."""
+    # Ensure socketio context is available. If called from a non-SocketIO thread,
+    # use socketio.emit directly.
     try:
-        log_entry = {
-            "message": message,
-            "emoji": emoji,
-            "type": log_type
-        }
-        # Output logs to terminal for user-friendly CLI experience
-        print(f"{emoji} {message}", flush=True)
-        # Emit as a JSON string to ensure valid JSON is sent
-        socketio.emit('log_message', json.dumps(log_entry, ensure_ascii=False))
+        log_entry = f"{emoji} {message}"
+        # Include log_type in the emitted data
+        socketio.emit('log_message', {'data': log_entry, 'type': log_type})
     except Exception:
         pass
 

--- a/webEvalAgent/src/tool_handlers.py
+++ b/webEvalAgent/src/tool_handlers.py
@@ -59,7 +59,6 @@ async def handle_web_evaluation(arguments: Dict[str, Any], ctx: Context, api_key
     """
     # Initialize log server immediately (if not already running)
     try:
-        # stop_log_server() # Commented out stop_log_server
         start_log_server()
         # Give the server a moment to start
         await asyncio.sleep(1)
@@ -192,8 +191,6 @@ async def handle_web_evaluation(arguments: Dict[str, Any], ctx: Context, api_key
     
     # MCP tool function expects list[list[TextContent, ImageContent]] - see docstring in mcp_server.py
     send_log(f"Returning wrapped response: list[ [{len(response)} items] ]", "🎁")
-    
-    # return [response]  # This structure may be incorrect
     
     # The correct structure based on docstring is list[list[TextContent, ImageContent]]
     # i.e., a list containing a single list of mixed content items


### PR DESCRIPTION
Made install way simpler with a direct UVX command:
uvx --from git+https://github.com/nandatheguntupalli/web-eval-agent.git webEvalAgent

Changes:
- Reworked mcp_server.py to handle its own config
- Added API key validation internally
- Kept same functionality, just easier to install

- No shell script dependencies
- Works the same, just less hassle to set up
- Same tool, cleaner installation

Just ripped out the extra installation steps. Everything else works exactly the same.