### PR TITLE
Change mcp dependency from >=1.6.0 to ==1.6.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "langchain>=0.3.21",
     "langchain-anthropic>=0.3.3",
     "langchain-google-genai>=2.0.10",
-    "mcp>=1.6.0",
+    "mcp==1.6.0",
     "python-dotenv>=1.1.0",
     "playwright>=1.41.0",
     "flask>=3.1.0",


### PR DESCRIPTION
Updated pyproject.toml -> MCP 1.10 includes some minor breaking changes that could affect a small number of FastMCP users.